### PR TITLE
Separate decisions data from scenarios

### DIFF
--- a/data/decisions.json
+++ b/data/decisions.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "EN01",
+    "title": "The Classic Trolley Problem",
+    "description": "A runaway trolley is heading towards five people tied to the tracks. You can pull a lever to divert it to a side track, but there's one person tied to that track.",
+    "track_a": "Pull the lever (save 5, kill 1)",
+    "track_b": "Do nothing (kill 5, save 1)",
+    "theme": "Utilitarian vs. Deontological Ethics",
+    "tags": ["classic", "numbers", "action_vs_inaction"],
+    "responses": [
+      {
+        "avatar": "Socrates",
+        "choice": "A",
+        "rationale": "The examined life requires us to act with wisdom. Saving five lives demonstrates care for the greater good."
+      },
+      {
+        "avatar": "Kant",
+        "choice": "B", 
+        "rationale": "We cannot use one person as a mere means to save others. The moral law forbids such instrumentalization."
+      }
+    ]
+  },
+  {
+    "id": "EN02",
+    "title": "The Ship of Theseus",
+    "description": "A passenger ship is sinking. You can save either the ship's original hull with 3 crew members, or the modernized engine room with 5 passengers.",
+    "track_a": "Save the original hull (3 crew)",
+    "track_b": "Save the engine room (5 passengers)",
+    "theme": "Identity vs. Utility",
+    "tags": ["identity", "numbers", "preservation"],
+    "responses": [
+      {
+        "avatar": "Aristotle",
+        "choice": "A",
+        "rationale": "The essence of the ship lies in its form and purpose. The crew maintains this continuity."
+      },
+      {
+        "avatar": "Mill",
+        "choice": "B",
+        "rationale": "The greatest happiness principle demands we save the greater number."
+      }
+    ]
+  },
+  {
+    "id": "EN03",
+    "title": "The Self-Driving Car",
+    "description": "An autonomous vehicle must choose between hitting an elderly person crossing legally or swerving to hit a young person jaywalking.",
+    "track_a": "Stay course (hit elderly legal crosser)",
+    "track_b": "Swerve (hit young jaywalker)",
+    "theme": "Legal vs. Utilitarian Calculation",
+    "tags": ["modern", "age", "law", "technology"],
+    "responses": [
+      {
+        "avatar": "Rawls",
+        "choice": "A",
+        "rationale": "Justice requires respecting legal frameworks. The elderly person followed the rules."
+      },
+      {
+        "avatar": "Singer",
+        "choice": "B",
+        "rationale": "Years of potential life matter. The utilitarian calculus favors saving the younger person."
+      }
+    ]
+  },
+  {
+    "id": "EN04",
+    "title": "The Organ Transplant",
+    "description": "A healthy person visits the hospital. You could harvest their organs to save five dying patients.",
+    "track_a": "Harvest organs (save 5, kill 1)",
+    "track_b": "Let nature take its course (5 die, 1 lives)",
+    "theme": "Active vs. Passive Harm",
+    "tags": ["medical", "active_harm", "numbers"],
+    "responses": [
+      {
+        "avatar": "Hippocrates",
+        "choice": "B",
+        "rationale": "First, do no harm. A physician must never actively harm a healthy patient."
+      },
+      {
+        "avatar": "Bentham",
+        "choice": "A",
+        "rationale": "The hedonic calculus is clear: five lives produce more happiness than one."
+      }
+    ]
+  },
+  {
+    "id": "EN05",
+    "title": "The Time Traveler's Dilemma",
+    "description": "You can prevent a natural disaster that kills 1000 people, but doing so will erase the existence of 100 people who were born because of that tragedy.",
+    "track_a": "Prevent disaster (save 1000, erase 100)",
+    "track_b": "Allow disaster (1000 die, 100 exist)",
+    "theme": "Temporal Ethics and Existence",
+    "tags": ["time_travel", "existence", "large_numbers"],
+    "responses": [
+      {
+        "avatar": "Parfit",
+        "choice": "A",
+        "rationale": "Non-identity problems aside, preventing suffering for existing people takes priority."
+      },
+      {
+        "avatar": "Nozick",
+        "choice": "B",
+        "rationale": "We cannot violate the rights of those who exist, even to prevent future harms."
+      }
+    ]
+  }
+]

--- a/data/scenarios.json
+++ b/data/scenarios.json
@@ -6,18 +6,10 @@
     "track_a": "Pull the lever (save 5, kill 1)",
     "track_b": "Do nothing (kill 5, save 1)",
     "theme": "Utilitarian vs. Deontological Ethics",
-    "tags": ["classic", "numbers", "action_vs_inaction"],
-    "responses": [
-      {
-        "avatar": "Socrates",
-        "choice": "A",
-        "rationale": "The examined life requires us to act with wisdom. Saving five lives demonstrates care for the greater good."
-      },
-      {
-        "avatar": "Kant",
-        "choice": "B", 
-        "rationale": "We cannot use one person as a mere means to save others. The moral law forbids such instrumentalization."
-      }
+    "tags": [
+      "classic",
+      "numbers",
+      "action_vs_inaction"
     ]
   },
   {
@@ -27,18 +19,10 @@
     "track_a": "Save the original hull (3 crew)",
     "track_b": "Save the engine room (5 passengers)",
     "theme": "Identity vs. Utility",
-    "tags": ["identity", "numbers", "preservation"],
-    "responses": [
-      {
-        "avatar": "Aristotle",
-        "choice": "A",
-        "rationale": "The essence of the ship lies in its form and purpose. The crew maintains this continuity."
-      },
-      {
-        "avatar": "Mill",
-        "choice": "B",
-        "rationale": "The greatest happiness principle demands we save the greater number."
-      }
+    "tags": [
+      "identity",
+      "numbers",
+      "preservation"
     ]
   },
   {
@@ -48,18 +32,11 @@
     "track_a": "Stay course (hit elderly legal crosser)",
     "track_b": "Swerve (hit young jaywalker)",
     "theme": "Legal vs. Utilitarian Calculation",
-    "tags": ["modern", "age", "law", "technology"],
-    "responses": [
-      {
-        "avatar": "Rawls",
-        "choice": "A",
-        "rationale": "Justice requires respecting legal frameworks. The elderly person followed the rules."
-      },
-      {
-        "avatar": "Singer",
-        "choice": "B",
-        "rationale": "Years of potential life matter. The utilitarian calculus favors saving the younger person."
-      }
+    "tags": [
+      "modern",
+      "age",
+      "law",
+      "technology"
     ]
   },
   {
@@ -69,18 +46,10 @@
     "track_a": "Harvest organs (save 5, kill 1)",
     "track_b": "Let nature take its course (5 die, 1 lives)",
     "theme": "Active vs. Passive Harm",
-    "tags": ["medical", "active_harm", "numbers"],
-    "responses": [
-      {
-        "avatar": "Hippocrates",
-        "choice": "B",
-        "rationale": "First, do no harm. A physician must never actively harm a healthy patient."
-      },
-      {
-        "avatar": "Bentham",
-        "choice": "A",
-        "rationale": "The hedonic calculus is clear: five lives produce more happiness than one."
-      }
+    "tags": [
+      "medical",
+      "active_harm",
+      "numbers"
     ]
   },
   {
@@ -90,18 +59,10 @@
     "track_a": "Prevent disaster (save 1000, erase 100)",
     "track_b": "Allow disaster (1000 die, 100 exist)",
     "theme": "Temporal Ethics and Existence",
-    "tags": ["time_travel", "existence", "large_numbers"],
-    "responses": [
-      {
-        "avatar": "Parfit",
-        "choice": "A",
-        "rationale": "Non-identity problems aside, preventing suffering for existing people takes priority."
-      },
-      {
-        "avatar": "Nozick",
-        "choice": "B",
-        "rationale": "We cannot violate the rights of those who exist, even to prevent future harms."
-      }
+    "tags": [
+      "time_travel",
+      "existence",
+      "large_numbers"
     ]
   }
 ]

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import type { Scenario } from "@/types";
 import { usePersonas } from "@/hooks/usePersonas";
+import { useDecisions } from "@/hooks/useDecisions";
 import NPCAvatar from "./NPCAvatar";
 import TrolleyDiagram from "./TrolleyDiagram";
 
@@ -12,9 +13,11 @@ interface ScenarioCardProps {
 const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
   const [showNPC, setShowNPC] = useState(false);
   const { personas } = usePersonas();
+  const { decisions } = useDecisions();
 
   const samples = useMemo(() => {
-    const r = scenario.responses ?? [];
+    const decision = decisions?.find(d => d.id === scenario.id);
+    const r = decision?.responses ?? [];
     const fromScenario = [...r].sort(() => Math.random() - 0.5).slice(0, 3);
     if (fromScenario.length > 0) return fromScenario;
 
@@ -29,7 +32,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
           Math.floor(Math.random() * (per.example_lines?.length ?? 0))
         ],
     }));
-  }, [scenario, personas]);
+  }, [scenario.id, decisions, personas]);
 
   return (
     <article className="space-y-6">

--- a/src/hooks/useDecisions.ts
+++ b/src/hooks/useDecisions.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import type { Decision } from "@/types";
+
+export function useDecisions() {
+  const [decisions, setDecisions] = useState<Decision[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = new URL("../../data/decisions.json", import.meta.url);
+    fetch(url)
+      .then(r => r.json())
+      .then((json: unknown) => {
+        if (Array.isArray(json)) {
+          setDecisions(json as Decision[]);
+        } else {
+          setDecisions([]);
+        }
+      })
+      .catch(() => setError("Failed to load decisions"));
+  }, []);
+
+  return { decisions, error, loading: decisions === null && !error };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export interface Response {
+  avatar: string;
+  choice: "A" | "B";
+  rationale?: string;
+}
+
 export interface Scenario {
   id: string;
   title: string;
@@ -6,9 +12,8 @@ export interface Scenario {
   track_b: string;
   theme?: string;
   tags?: string[];
-  responses?: Array<{
-    avatar: string;
-    choice: "A" | "B";
-    rationale?: string;
-  }>;
+}
+
+export interface Decision extends Scenario {
+  responses: Response[];
 }


### PR DESCRIPTION
## Summary
- Move NPC responses from `scenarios.json` into new `decisions.json`
- Update types and hooks to load decisions separately
- Fetch decision responses in `ScenarioCard` instead of from scenario metadata

## Testing
- `npm run lint` (fails: Fast refresh warnings, no-empty-object-type, no-explicit-any, no-require-imports)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c01f4b2788330a32d8946bbeaf304