### PR TITLE
Add run history and replay functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Play from "./pages/Play";
 import Results from "./pages/Results";
+import History from "./pages/History";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -17,9 +18,10 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/play" element={<Play />} />
-          <Route path="/results" element={<Results />} />
+            <Route path="/" element={<Index />} />
+            <Route path="/play" element={<Play />} />
+            <Route path="/results" element={<Results />} />
+            <Route path="/history" element={<History />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 
+export interface HistoryEntry<T> {
+  timestamp: number;
+  value: T;
+}
+
 export function useLocalStorage<T>(key: string, initialValue: T) {
   const [value, setValue] = useState<T>(() => {
     try {
@@ -10,6 +15,31 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     }
   });
 
+  const historyKey = `${key}-history`;
+
+  function getHistory(): HistoryEntry<T>[] {
+    try {
+      const raw = window.localStorage.getItem(historyKey);
+      return raw ? (JSON.parse(raw) as HistoryEntry<T>[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function recordHistory(entry: T) {
+    try {
+      const history = getHistory();
+      const last = history[history.length - 1];
+      // Avoid recording duplicate consecutive runs
+      if (!last || JSON.stringify(last.value) !== JSON.stringify(entry)) {
+        history.push({ timestamp: Date.now(), value: entry });
+        window.localStorage.setItem(historyKey, JSON.stringify(history));
+      }
+    } catch {
+      // ignore write errors
+    }
+  }
+
   useEffect(() => {
     try {
       window.localStorage.setItem(key, JSON.stringify(value));
@@ -18,5 +48,5 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
     }
   }, [key, value]);
 
-  return [value, setValue] as const;
+  return [value, setValue, { history: getHistory(), recordHistory }] as const;
 }

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useScenarios } from "@/hooks/useScenarios";
+import { computeAxes_legacy as computeAxes, computeBaseCounts, Choice } from "@/utils/scoring";
+
+const ANSWERS_KEY = "trolleyd-answers";
+
+const History = () => {
+  useEffect(() => { document.title = "Trolley’d · History"; }, []);
+  const navigate = useNavigate();
+  const { scenarios } = useScenarios();
+  const [, setAnswers, { history }] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+
+  if (!history.length) {
+    return (
+      <main className="min-h-screen container max-w-3xl py-8">
+        <h1 className="text-3xl font-bold mb-4">History</h1>
+        <p className="text-muted-foreground">No completed runs yet.</p>
+      </main>
+    );
+  }
+
+  const runs = [...history].reverse();
+
+  return (
+    <main className="min-h-screen container max-w-3xl py-8 space-y-6">
+      <header>
+        <h1 className="text-3xl font-bold">History</h1>
+      </header>
+      <ul className="space-y-4">
+        {runs.map((run) => {
+          const { scoreA, scoreB } = computeBaseCounts(run.value);
+          const axes = computeAxes(scenarios ?? [], run.value);
+          const date = new Date(run.timestamp).toLocaleString();
+          return (
+            <li key={run.timestamp} className="p-4 rounded-lg border border-border bg-card space-y-2">
+              <div className="flex items-center justify-between">
+                <div className="font-semibold">{date}</div>
+                <button
+                  onClick={() => { setAnswers(run.value); navigate("/play"); }}
+                  className="text-sm underline underline-offset-4"
+                >Replay</button>
+              </div>
+              <div className="text-sm text-muted-foreground">A: {scoreA} · B: {scoreB}</div>
+              <div className="text-xs text-muted-foreground">
+                Order-Chaos: {axes.orderChaos} · Material-Social: {axes.materialSocial} · Mercy-Mischief: {axes.mercyMischief}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </main>
+  );
+};
+
+export default History;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,8 +8,8 @@ const Index = () => {
   
   return (
     <main className="min-h-screen container max-w-2xl py-16">
-      <div className="text-center animate-fade-in">
-        <h1 className="text-4xl font-bold mb-4">Trolley'd</h1>
+        <div className="text-center animate-fade-in">
+          <h1 className="text-4xl font-bold mb-4">Trolley'd</h1>
         <p className="text-lg text-muted-foreground mb-8 max-w-md mx-auto">
           A tiny, monochrome thought‑experiment game. Pick Track A or B through a series of scenarios and see where your compass points.
         </p>
@@ -23,16 +23,22 @@ const Index = () => {
           />
         </div>
         
-        <button
-          onClick={() => navigate("/play")}
-          className="px-8 py-4 rounded-lg border border-border bg-card hover:bg-accent transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring transform hover:scale-105 active:scale-95 font-medium text-lg"
-          aria-label="Start playing Trolley'd"
-        >
-          Begin Your Journey
-        </button>
-      </div>
-    </main>
-  );
+          <button
+            onClick={() => navigate("/play")}
+            className="px-8 py-4 rounded-lg border border-border bg-card hover:bg-accent transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring transform hover:scale-105 active:scale-95 font-medium text-lg"
+            aria-label="Start playing Trolley'd"
+          >
+            Begin Your Journey
+          </button>
+          <div className="mt-6">
+            <button
+              onClick={() => navigate("/history")}
+              className="text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            >View History</button>
+          </div>
+        </div>
+      </main>
+    );
 };
 
 export default Index;

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -12,10 +12,16 @@ const Results = () => {
   useEffect(() => { document.title = "Trolley’d · Results"; }, []);
   const navigate = useNavigate();
   const { scenarios } = useScenarios();
-  const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+  const [answers, setAnswers, { recordHistory }] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
 
   const { scoreA, scoreB } = useMemo(() => computeBaseCounts(answers), [answers]);
   const axes = useMemo(() => computeAxes(scenarios ?? [], answers), [scenarios, answers]);
+
+  useEffect(() => {
+    if (Object.keys(answers).length > 0) {
+      recordHistory(answers);
+    }
+  }, [answers, recordHistory]);
 
   if (!scenarios) return (
     <main className="min-h-screen container py-10" />
@@ -100,6 +106,10 @@ const Results = () => {
             onClick={() => { localStorage.removeItem(ANSWERS_KEY); setAnswers({}); navigate("/play"); }}
             className="px-4 py-2 rounded-md border border-border hover:bg-accent"
           >Reset game</button>
+          <Link
+            to="/history"
+            className="px-4 py-2 rounded-md border border-border hover:bg-accent"
+          >View History</Link>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- track run history in localStorage with timestamps
- add history page to list past runs and allow replay
- link history page from landing and results pages and add route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; An interface declaring no members is equivalent to its supertype; Unexpected any; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c02d450548330922f7cf8207aa382