### PR TITLE
feat: enhance progress tracking

### DIFF
--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -1,13 +1,20 @@
 import React from "react";
 
 interface ProgressProps {
-  value: number; // 0..1
+  value: number; // 0..100
 }
 
 const Progress: React.FC<ProgressProps> = ({ value }) => {
-  const pct = Math.max(0, Math.min(1, value)) * 100;
+  const pct = Math.max(0, Math.min(100, value));
   return (
-    <div className="w-full h-2 rounded-md bg-muted overflow-hidden" aria-hidden>
+    <div
+      className="w-full h-2 rounded-md bg-muted overflow-hidden"
+      role="progressbar"
+      aria-label="Progress"
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
       <div
         className="h-full bg-foreground/80 transition-all"
         style={{ width: `${pct}%` }}

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -57,7 +57,12 @@ const Play = () => {
     );
   }
   const s = scenarios[index] as Scenario;
-  const progress = (index + 1) / total;
+  const progress = ((index + 1) / total) * 100;
+
+  const values = Object.values(answers);
+  const skipped = values.filter(v => v === "skip").length;
+  const answeredCount = values.filter(v => v !== "skip").length;
+  const left = total - answeredCount;
 
   function advance() {
     // next unanswered or end
@@ -83,6 +88,13 @@ const Play = () => {
     advance();
   }
 
+  function reviewSkipped() {
+    const next = scenarios.find(sc => answers[sc.id] === "skip");
+    if (next) {
+      navigate(`/play?jump=${next.id}`);
+    }
+  }
+
   return (
     <main className="min-h-screen container max-w-2xl py-8 space-y-6">
       <section className="space-y-4 animate-fade-in">
@@ -90,22 +102,34 @@ const Play = () => {
           <div className="text-sm text-muted-foreground font-medium">
             Question {index + 1} of {total}
           </div>
-          <button 
-            onClick={() => navigate("/results")} 
-            className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
-          >
-            End & See Results
-          </button>
+          <div className="flex items-center gap-4">
+            {skipped > 0 && (
+              <button
+                onClick={reviewSkipped}
+                className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+              >
+                Review skipped
+              </button>
+            )}
+            <button
+              onClick={() => navigate("/results")}
+              className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+            >
+              End & See Results
+            </button>
+          </div>
         </div>
         <div className="space-y-2">
           <div className="h-2 animate-scale-in">
-            <Progress value={progress * 100} />
+            <Progress value={progress} />
           </div>
           <div className="flex justify-between text-xs text-muted-foreground">
-            <span>Start</span>
-            <span>{Math.round(progress * 100)}% Complete</span>
-            <span>Finish</span>
+            <span>{skipped} skipped</span>
+            <span>{Math.round(progress)}% complete · {left} left</span>
           </div>
+        </div>
+        <div aria-live="polite" className="sr-only">
+          {`Question ${index + 1} of ${total}. ${skipped} skipped. ${left} left.`}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add accessible progress bar with ARIA labels
- show skipped and remaining counts with review button
- announce progress updates via aria-live region

## Testing
- `npm run lint` (fails: no-empty-object-type, no-explicit-any, no-require-imports)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c0530c6a48330b24dc6597155dfd6