### PR TITLE
feat: add accessibility settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Play from "./pages/Play";
 import Results from "./pages/Results";
+import Settings from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -20,6 +21,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/play" element={<Play />} />
           <Route path="/results" element={<Results />} />
+          <Route path="/settings" element={<Settings />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/TrolleyDiagram.tsx
+++ b/src/components/TrolleyDiagram.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 
 interface TrolleyDiagramProps {
   trackALabel?: string;
@@ -6,11 +7,13 @@ interface TrolleyDiagramProps {
   className?: string;
 }
 
-const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({ 
-  trackALabel = "Track A", 
+const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({
+  trackALabel = "Track A",
   trackBLabel = "Track B",
   className = ""
 }) => {
+  const reduced = useReducedMotion();
+
   return (
     <div className={`w-full max-w-md mx-auto ${className}`}>
       <svg 
@@ -44,7 +47,7 @@ const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({
         />
         
         {/* Trolley */}
-        <g className="animate-trolley-move">
+        <g className={reduced ? undefined : "animate-trolley-move"}>
           <rect
             x="40"
             y="88"

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "trolleyd-reduced-motion";
+
+function getInitialValue() {
+  if (typeof window === "undefined") return false;
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored !== null) return stored === "true";
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function useReducedMotion() {
+  const [reduced, setReduced] = useState<boolean>(getInitialValue);
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(getInitialValue());
+    const storage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) update();
+    };
+    media.addEventListener("change", update);
+    window.addEventListener("storage", storage);
+    return () => {
+      media.removeEventListener("change", update);
+      window.removeEventListener("storage", storage);
+    };
+  }, []);
+
+  return reduced;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,24 @@ All colors MUST be HSL.
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
+
+  .high-contrast {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 0%;
+    --trolley-track: 0 0% 0%;
+    --trolley-body: 0 0% 0%;
+    --choice-hover: 0 0% 90%;
+    --progress-fill: 0 0% 0%;
+  }
+
+  .dark.high-contrast {
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
+    --trolley-track: 0 0% 100%;
+    --trolley-body: 0 0% 100%;
+    --choice-hover: 0 0% 20%;
+    --progress-fill: 0 0% 100%;
+  }
 }
 
 @layer base {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,18 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
+const rootEl = document.documentElement
+
+if (localStorage.getItem('trolleyd-high-contrast') === 'true') {
+  rootEl.classList.add('high-contrast')
+}
+
+const rmStored = localStorage.getItem('trolleyd-reduced-motion')
+if (
+  rmStored === 'true' ||
+  (rmStored === null && window.matchMedia('(prefers-reduced-motion: reduce)').matches)
+) {
+  rootEl.classList.add('reduced-motion')
+}
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -30,6 +30,14 @@ const Index = () => {
         >
           Begin Your Journey
         </button>
+        <div className="mt-4">
+          <button
+            onClick={() => navigate("/settings")}
+            className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4"
+          >
+            Settings
+          </button>
+        </div>
       </div>
     </main>
   );

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Switch } from "@/components/ui/switch";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+
+const Settings = () => {
+  useEffect(() => { document.title = "Trolley'd · Settings"; }, []);
+  const navigate = useNavigate();
+  const [highContrast, setHighContrast] = useLocalStorage<boolean>("trolleyd-high-contrast", false);
+  const [reducedMotion, setReducedMotion] = useLocalStorage<boolean>(
+    "trolleyd-reduced-motion",
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("high-contrast", highContrast);
+  }, [highContrast]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("reduced-motion", reducedMotion);
+  }, [reducedMotion]);
+
+  return (
+    <main className="min-h-screen container max-w-2xl py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Settings</h1>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <label htmlFor="high-contrast" className="text-sm font-medium">
+            High Contrast
+          </label>
+          <Switch id="high-contrast" checked={highContrast} onCheckedChange={setHighContrast} />
+        </div>
+        <div className="flex items-center justify-between">
+          <label htmlFor="reduced-motion" className="text-sm font-medium">
+            Reduced Motion
+          </label>
+          <Switch id="reduced-motion" checked={reducedMotion} onCheckedChange={setReducedMotion} />
+        </div>
+      </div>
+      <button
+        onClick={() => navigate(-1)}
+        className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4"
+      >
+        Back
+      </button>
+    </main>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add reduced-motion hook and disable trolley animation for users who prefer less motion
- introduce high-contrast and reduced-motion settings with persistence
- wire settings page and apply tokens on load

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any; A require() style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c05319108833087fbda39e87fd88d