### PR TITLE
Add analytics stubs and integrate with gameplay

### DIFF
--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -6,6 +6,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useScenarios } from "@/hooks/useScenarios";
 import type { Scenario } from "@/types";
 import type { Choice } from "@/utils/scoring";
+import { scenario_shown, choice_made } from "@/utils/analytics";
 
 const ANSWERS_KEY = "trolleyd-answers";
 
@@ -38,6 +39,14 @@ const Play = () => {
     return () => window.removeEventListener("keydown", onKey);
   });
 
+  const total = scenarios?.length ?? 0;
+  const s = scenarios?.[index] as Scenario | undefined;
+  const progress = total ? (index + 1) / total : 0;
+
+  useEffect(() => {
+    if (s) scenario_shown(s.id);
+  }, [s]);
+
   if (loading || !scenarios) {
     return (
       <main className="min-h-screen container py-10">
@@ -48,7 +57,6 @@ const Play = () => {
     );
   }
 
-  const total = scenarios.length;
   if (total === 0) {
     return (
       <main className="min-h-screen container max-w-2xl py-8">
@@ -56,8 +64,6 @@ const Play = () => {
       </main>
     );
   }
-  const s = scenarios[index] as Scenario;
-  const progress = (index + 1) / total;
 
   function advance() {
     // next unanswered or end
@@ -74,12 +80,14 @@ const Play = () => {
   function pick(choice: "A" | "B") {
     if (!s) return;
     setAnswers({ ...answers, [s.id]: choice });
+    choice_made(s.id, choice);
     advance();
   }
 
   function skip() {
     if (!s) return;
     setAnswers({ ...answers, [s.id]: "skip" });
+    choice_made(s.id, "skip");
     advance();
   }
 

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -5,11 +5,15 @@ import TrolleyDiagram from "@/components/TrolleyDiagram";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useScenarios } from "@/hooks/useScenarios";
 import { Choice, computeAxes_legacy as computeAxes, computeBaseCounts } from "@/utils/scoring";
+import { results_viewed } from "@/utils/analytics";
 
 const ANSWERS_KEY = "trolleyd-answers";
 
 const Results = () => {
-  useEffect(() => { document.title = "Trolley’d · Results"; }, []);
+  useEffect(() => {
+    document.title = "Trolley’d · Results";
+    results_viewed();
+  }, []);
   const navigate = useNavigate();
   const { scenarios } = useScenarios();
   const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,14 @@
+export function scenario_shown(id: string) {
+  if (import.meta.env.DEV) return;
+  // TODO: integrate with Supabase or external persistence to record when a scenario is viewed
+}
+
+export function choice_made(id: string, choice: string) {
+  if (import.meta.env.DEV) return;
+  // TODO: integrate with Supabase or external persistence to record a player's choice
+}
+
+export function results_viewed() {
+  if (import.meta.env.DEV) return;
+  // TODO: integrate with Supabase or external persistence to record when results are viewed
+}


### PR DESCRIPTION
## Summary
- add placeholder analytics utilities to track scenario and result events
- wire Play page to send analytics on scenario view and choice made
- trigger analytics when results page is viewed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_689c053302c88330983c892b77c88b2e