### PR TITLE
chore: standardize scenario tags

### DIFF
--- a/data/scenarios.json
+++ b/data/scenarios.json
@@ -6,7 +6,7 @@
     "track_a": "Pull the lever (save 5, kill 1)",
     "track_b": "Do nothing (kill 5, save 1)",
     "theme": "Utilitarian vs. Deontological Ethics",
-    "tags": ["classic", "numbers", "action_vs_inaction"],
+    "tags": [],
     "responses": [
       {
         "avatar": "Socrates",
@@ -27,7 +27,7 @@
     "track_a": "Save the original hull (3 crew)",
     "track_b": "Save the engine room (5 passengers)",
     "theme": "Identity vs. Utility",
-    "tags": ["identity", "numbers", "preservation"],
+    "tags": ["identity"],
     "responses": [
       {
         "avatar": "Aristotle",
@@ -48,7 +48,7 @@
     "track_a": "Stay course (hit elderly legal crosser)",
     "track_b": "Swerve (hit young jaywalker)",
     "theme": "Legal vs. Utilitarian Calculation",
-    "tags": ["modern", "age", "law", "technology"],
+    "tags": ["law", "technology", "age"],
     "responses": [
       {
         "avatar": "Rawls",
@@ -69,7 +69,7 @@
     "track_a": "Harvest organs (save 5, kill 1)",
     "track_b": "Let nature take its course (5 die, 1 lives)",
     "theme": "Active vs. Passive Harm",
-    "tags": ["medical", "active_harm", "numbers"],
+    "tags": ["medical"],
     "responses": [
       {
         "avatar": "Hippocrates",
@@ -90,7 +90,7 @@
     "track_a": "Prevent disaster (save 1000, erase 100)",
     "track_b": "Allow disaster (1000 die, 100 exist)",
     "theme": "Temporal Ethics and Existence",
-    "tags": ["time_travel", "existence", "large_numbers"],
+    "tags": ["time_travel", "existence"],
     "responses": [
       {
         "avatar": "Parfit",

--- a/src/hooks/useScenarios.ts
+++ b/src/hooks/useScenarios.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { Scenario } from "@/types";
+import { tagsSchema } from "@/utils/tags.schema";
 
 export function useScenarios() {
   const [scenarios, setScenarios] = useState<Scenario[] | null>(null);
@@ -11,7 +12,14 @@ export function useScenarios() {
       .then(r => r.json())
       .then((json: unknown) => {
         if (Array.isArray(json)) {
-          setScenarios(json as Scenario[]);
+          const parsed = json.map(s => {
+            const raw = s as Record<string, unknown>;
+            const tags = tagsSchema.safeParse(raw.tags).success
+              ? tagsSchema.parse(raw.tags)
+              : [];
+            return { ...(raw as Scenario), tags };
+          });
+          setScenarios(parsed as Scenario[]);
         } else {
           setScenarios([]);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Tag } from "@/utils/tags.schema";
+
 export interface Scenario {
   id: string;
   title: string;
@@ -5,7 +7,7 @@ export interface Scenario {
   track_a: string;
   track_b: string;
   theme?: string;
-  tags?: string[];
+  tags?: Tag[];
   responses?: Array<{
     avatar: string;
     choice: "A" | "B";

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -1,4 +1,5 @@
 import type { Scenario } from "@/types";
+import { canonicalTags } from "@/utils/tags.schema";
 
 export function countAB(answers: Record<string, "A"|"B"|"skip">) {
   return Object.values(answers).reduce(
@@ -11,10 +12,10 @@ export function countAB(answers: Record<string, "A"|"B"|"skip">) {
   );
 }
 
-const ORDER = new Set(["bureaucracy", "standards", "logistics"]);
-const CHAOS = new Set(["absurd", "paradox", "infinite"]);
-const MATERIAL = new Set(["reality", "manufacturing_defects", "quality_control", "space"]);
-const SOCIAL = new Set(["identity", "meaning", "workers_rights", "existential"]);
+const ORDER = new Set(canonicalTags.ORDER);
+const CHAOS = new Set(canonicalTags.CHAOS);
+const MATERIAL = new Set(canonicalTags.MATERIAL);
+const SOCIAL = new Set(canonicalTags.SOCIAL);
 
 const MISCHIEF_WORDS = ["hit", "tow", "deny", "erase", "confine", "condemn", "break"];
 

--- a/src/utils/tags.schema.ts
+++ b/src/utils/tags.schema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const canonicalTags = {
+  ORDER: ["law"] as const,
+  CHAOS: ["time_travel"] as const,
+  MATERIAL: ["technology", "medical"] as const,
+  SOCIAL: ["identity", "existence", "age"] as const,
+} as const;
+
+const allTags = [
+  ...canonicalTags.ORDER,
+  ...canonicalTags.CHAOS,
+  ...canonicalTags.MATERIAL,
+  ...canonicalTags.SOCIAL,
+] as const;
+
+export const tagSchema = z.enum(allTags);
+export const tagsSchema = z.array(tagSchema);
+
+export type Tag = z.infer<typeof tagSchema>;


### PR DESCRIPTION
## Summary
- define canonical tag list for order, chaos, material, and social axes
- validate scenario tags with zod and update scenario definitions
- track canonical tags in scoring logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 4 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689c00ac9bec8330b6cec707e8554f7b