### PR TITLE
Add tests and CI for scoring and gameplay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  pull_request:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@eslint/js": "^9.32.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
@@ -78,6 +80,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ScenarioCard from './ScenarioCard';
+import type { Scenario } from '@/types';
+
+const scenario: Scenario = {
+  id: '1',
+  title: 'Title',
+  track_a: 'Do A',
+  track_b: 'Do B',
+  responses: [{ avatar: 'NPC', choice: 'A', rationale: 'Because' }],
+};
+
+describe('ScenarioCard', () => {
+  it('handles A/B choices', () => {
+    const onPick = vi.fn();
+    render(<ScenarioCard scenario={scenario} onPick={onPick} />);
+    fireEvent.click(screen.getByRole('button', { name: /choose track a/i }));
+    fireEvent.click(screen.getByRole('button', { name: /choose track b/i }));
+    expect(onPick).toHaveBeenCalledWith('A');
+    expect(onPick).toHaveBeenCalledWith('B');
+  });
+
+  it('toggles NPC samples', () => {
+    render(<ScenarioCard scenario={scenario} onPick={() => {}} />);
+    const toggle = screen.getByRole('button', { name: /see sample npc takes/i });
+    expect(screen.queryByText('NPC')).toBeNull();
+    fireEvent.click(toggle);
+    expect(screen.queryByText('NPC')).not.toBeNull();
+  });
+});

--- a/src/hooks/usePersonas.test.ts
+++ b/src/hooks/usePersonas.test.ts
@@ -1,0 +1,24 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePersonas } from './usePersonas';
+
+describe('usePersonas', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns personas on success', async () => {
+    const data = [{ name: 'Alice' }];
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve(data) })) as any);
+    const { result } = renderHook(() => usePersonas());
+    await waitFor(() => expect(result.current.personas).toEqual(data));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('reports error on failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('fail'))));
+    const { result } = renderHook(() => usePersonas());
+    await waitFor(() => expect(result.current.error).toBe('Failed to load personas'));
+    expect(result.current.personas).toBeNull();
+  });
+});

--- a/src/hooks/useScenarios.test.ts
+++ b/src/hooks/useScenarios.test.ts
@@ -1,0 +1,24 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useScenarios } from './useScenarios';
+
+describe('useScenarios', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns scenarios on success', async () => {
+    const data = [{ id: '1', title: 't', track_a: 'a', track_b: 'b' }];
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve(data) })) as any);
+    const { result } = renderHook(() => useScenarios());
+    await waitFor(() => expect(result.current.scenarios).toEqual(data));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('reports error on failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('fail'))));
+    const { result } = renderHook(() => useScenarios());
+    await waitFor(() => expect(result.current.error).toBe('Failed to load scenarios'));
+    expect(result.current.scenarios).toBeNull();
+  });
+});

--- a/src/pages/Play.test.tsx
+++ b/src/pages/Play.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Play from './Play';
+import type { Scenario } from '@/types';
+import { useScenarios } from '@/hooks/useScenarios';
+
+vi.mock('@/hooks/useScenarios');
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual: any = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockedUseScenarios = useScenarios as unknown as vi.Mock;
+
+describe('Play page', () => {
+  const scenarios: Scenario[] = [
+    { id: '1', title: 'One', track_a: 'A1', track_b: 'B1' },
+    { id: '2', title: 'Two', track_a: 'A2', track_b: 'B2' },
+  ];
+
+  beforeEach(() => {
+    mockedUseScenarios.mockReturnValue({ scenarios, loading: false });
+    mockNavigate.mockReset();
+    window.localStorage.clear();
+  });
+
+  it('picks A with left arrow', async () => {
+    render(<MemoryRouter initialEntries={['/play']}><Play /></MemoryRouter>);
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    await waitFor(() => {
+      const stored = JSON.parse(window.localStorage.getItem('trolleyd-answers') || '{}');
+      return stored['1'] === 'A';
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it('picks B with right arrow', async () => {
+    render(<MemoryRouter initialEntries={['/play']}><Play /></MemoryRouter>);
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    await waitFor(() => {
+      const stored = JSON.parse(window.localStorage.getItem('trolleyd-answers') || '{}');
+      return stored['1'] === 'B';
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it('skips with S key', async () => {
+    render(<MemoryRouter initialEntries={['/play']}><Play /></MemoryRouter>);
+    fireEvent.keyDown(window, { key: 's' });
+    await waitFor(() => {
+      const stored = JSON.parse(window.localStorage.getItem('trolleyd-answers') || '{}');
+      return stored['1'] === 'skip';
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it('navigates to first skipped scenario', () => {
+    window.localStorage.setItem('trolleyd-answers', JSON.stringify({ '1': 'skip' }));
+    render(<MemoryRouter initialEntries={['/play']}><Play /></MemoryRouter>);
+    const review = screen.getByRole('button', { name: /review skipped/i });
+    fireEvent.click(review);
+    expect(mockNavigate).toHaveBeenCalledWith('/play?jump=1');
+  });
+});

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -15,6 +15,7 @@ const Play = () => {
   const { scenarios, loading } = useScenarios();
   const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
   const [params] = useSearchParams();
+  const hasSkipped = useMemo(() => Object.values(answers).includes("skip"), [answers]);
 
   const index = useMemo(() => {
     if (!scenarios) return 0;
@@ -83,6 +84,12 @@ const Play = () => {
     advance();
   }
 
+  function reviewSkipped() {
+    if (!scenarios) return;
+    const first = scenarios.find(sc => answers[sc.id] === "skip");
+    if (first) navigate(`/play?jump=${first.id}`);
+  }
+
   return (
     <main className="min-h-screen container max-w-2xl py-8 space-y-6">
       <section className="space-y-4 animate-fade-in">
@@ -114,12 +121,22 @@ const Play = () => {
       )}
 
       <div className="flex items-center justify-between pt-4">
-        <button 
-          onClick={skip} 
-          className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
-        >
-          Skip this scenario
-        </button>
+        <div className="space-x-4">
+          <button
+            onClick={skip}
+            className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+          >
+            Skip this scenario
+          </button>
+          {hasSkipped && (
+            <button
+              onClick={reviewSkipped}
+              className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+            >
+              Review skipped
+            </button>
+          )}
+        </div>
         <div className="text-xs text-muted-foreground bg-muted/50 px-3 py-1 rounded-full">
           Shortcuts: ← A · → B · S Skip
         </div>

--- a/src/utils/scoring.test.ts
+++ b/src/utils/scoring.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { countAB, computeAxes, computeBaseCounts } from './scoring';
+import type { Scenario } from '@/types';
+
+describe('countAB', () => {
+  it('counts A and B choices', () => {
+    const answers = { one: 'A', two: 'B', three: 'skip' } as const;
+    expect(countAB(answers)).toEqual({ A: 1, B: 1 });
+  });
+});
+
+describe('computeAxes', () => {
+  it('derives axis totals from scenarios', () => {
+    const scenarios: Scenario[] = [
+      { id: '1', title: 's1', track_a: 'Help', track_b: 'Harm', tags: ['bureaucracy', 'reality'] },
+      { id: '2', title: 's2', track_a: 'Aid', track_b: 'Tow', tags: ['absurd', 'identity'] },
+      { id: '3', title: 's3', track_a: 'foo', track_b: 'bar', tags: ['space'] },
+    ];
+    const answers = { '1': 'A', '2': 'B', '3': 'skip' } as const;
+    const axes = computeAxes(answers, scenarios);
+    expect(axes).toEqual({ order: 1, chaos: 1, material: 2, social: 1, mercy: 1, mischief: 1 });
+  });
+});
+
+describe('computeBaseCounts', () => {
+  it('maps countAB to legacy structure', () => {
+    const answers = { a: 'A', b: 'B', c: 'B' } as const;
+    expect(computeBaseCounts(answers)).toEqual({ scoreA: 1, scoreB: 2 });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,8 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
+  },
 }));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+// vitest setup file


### PR DESCRIPTION
## Summary
- add vitest and testing-library deps with npm test script
- cover scoring utils, hooks, ScenarioCard, and Play page
- show "Review skipped" button and wire into navigation
- run tests in GitHub Actions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c0084ac008330920cd999f003581f