### PR TITLE
feat: validate decisions with canonical tags

### DIFF
--- a/src/utils/decisions.schema.ts
+++ b/src/utils/decisions.schema.ts
@@ -1,11 +1,13 @@
 
 import { z } from "zod";
+import { tagSchema } from "./tags.schema";
 
 export const decisionSchema = z.object({
   scenarioId: z.string(),
   persona: z.string(),
   choice: z.enum(["A", "B"]),
   rationale: z.string().optional(),
+  tags: z.array(tagSchema).optional(),
 });
 
 export type Decision = z.infer<typeof decisionSchema>;


### PR DESCRIPTION
## Summary
- add canonical tag support to `Decision` schema
- normalize and validate decision data with Zod

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689c168833d0833090cf048dd2c7da7e