### PR TITLE
feat(types): add Decision type

### DIFF
--- a/src/hooks/useDecisions.ts
+++ b/src/hooks/useDecisions.ts
@@ -1,7 +1,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { fetchWithRetry } from "@/utils/fetchWithRetry";
-import { decisionSchema, type Decision } from "@/utils/decisions.schema";
+import { decisionSchema } from "@/utils/decisions.schema";
+import type { Decision } from "@/types";
 
 export function useDecisions() {
   const [decisions, setDecisions] = useState<Decision[] | null>(null);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,8 @@
-
 export type { Scenario, Persona, Tag } from "./utils/tags.schema";
-export type { Decision } from "./utils/decisions.schema";
+
+export type Decision = {
+  scenarioId: string;
+  persona: string;
+  choice: "A" | "B";
+  rationale?: string;
+};

--- a/src/utils/decisions.schema.ts
+++ b/src/utils/decisions.schema.ts
@@ -7,5 +7,3 @@ export const decisionSchema = z.object({
   choice: z.enum(["A", "B"]),
   rationale: z.string().optional(),
 });
-
-export type Decision = z.infer<typeof decisionSchema>;


### PR DESCRIPTION
## Summary
- add Decision type definition and export
- update Decision hook imports to use new type
- remove decision type export from decision schema

## Testing
- `npm test` *(fails: window.matchMedia is not a function; scoring test expectation)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c16c3e85c833086325268f35e635b