### PR TITLE
feat: allow custom className in Progress component

### DIFF
--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -1,5 +1,6 @@
 
 import React from "react";
+import { cn } from "@/lib/utils";
 
 interface ProgressProps {
   value: number; // 0..100
@@ -10,7 +11,7 @@ const Progress: React.FC<ProgressProps> = ({ value, className }) => {
   const pct = Math.max(0, Math.min(100, value));
   return (
     <div
-      className={`w-full h-2 rounded-md bg-muted overflow-hidden ${className ?? ""}`}
+      className={cn("w-full h-2 rounded-md bg-muted overflow-hidden", className)}
       role="progressbar"
       aria-label="Progress"
       aria-valuenow={pct}


### PR DESCRIPTION
## Summary
- add optional className prop to Progress component
- merge component styles with cn utility

## Testing
- `npm test` *(fails: window.matchMedia is not a function; expected +0 to be 1)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c16e0483c8330833e0ea3dbdba0d9