### PR TITLE
feat: add decision type

### DIFF
--- a/src/hooks/useDecisions.ts
+++ b/src/hooks/useDecisions.ts
@@ -1,7 +1,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { fetchWithRetry } from "@/utils/fetchWithRetry";
-import { decisionSchema, type Decision } from "@/utils/decisions.schema";
+import { decisionSchema } from "@/utils/decisions.schema";
+import type { Decision } from "@/types";
 
 export function useDecisions() {
   const [decisions, setDecisions] = useState<Decision[] | null>(null);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
 
 export type { Scenario, Persona, Tag } from "./utils/tags.schema";
-export type { Decision } from "./utils/decisions.schema";
+
+export type Decision = {
+  scenarioId: string;
+  persona: string;
+  choice: "A" | "B";
+  rationale?: string;
+};


### PR DESCRIPTION
## Summary
- add explicit Decision type
- use centralized Decision type in decisions hook

## Testing
- `npm test` (fails: window.matchMedia is not a function; expected +0 to be 1)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c189dbedc8330a8380583af2ccf7c