### PR TITLE
feat: add avatar generator page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import Play from "./pages/Play";
 import Results from "./pages/Results";
 import NotFound from "./pages/NotFound";
+import Avatar from "./pages/Avatar";
 
 const queryClient = new QueryClient();
 
@@ -20,6 +21,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/play" element={<Play />} />
           <Route path="/results" element={<Results />} />
+          <Route path="/avatar" element={<Avatar />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/lib/stableDiffusion.ts
+++ b/src/lib/stableDiffusion.ts
@@ -1,0 +1,6 @@
+export async function generateAvatarImage(prompt: string, apiKey: string): Promise<string> {
+  // Placeholder for HuggingFace Stable Diffusion API call.
+  // The API key will be supplied at runtime.
+  // TODO: implement API call to generate an avatar image from the prompt.
+  return "https://placehold.co/256x256";
+}

--- a/src/pages/Avatar.tsx
+++ b/src/pages/Avatar.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { generateAvatarImage } from "@/lib/stableDiffusion";
+
+const AvatarPage = () => {
+  const [prompt, setPrompt] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const url = await generateAvatarImage(prompt, apiKey);
+    setImageUrl(url);
+  };
+
+  return (
+    <main className="container max-w-md py-10">
+      <h1 className="text-2xl font-bold mb-4">Avatar Generator</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Describe your avatar"
+        />
+        <Input
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="HuggingFace API key"
+          type="password"
+        />
+        <Button type="submit">Generate</Button>
+      </form>
+      <div className="mt-6">
+        <Avatar className="h-24 w-24">
+          {imageUrl ? (
+            <AvatarImage src={imageUrl} alt="Generated avatar" />
+          ) : (
+            <AvatarFallback>Preview</AvatarFallback>
+          )}
+        </Avatar>
+      </div>
+    </main>
+  );
+};
+
+export default AvatarPage;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -30,6 +30,14 @@ const Index = () => {
         >
           Begin Your Journey
         </button>
+        <div className="mt-4">
+          <button
+            onClick={() => navigate("/avatar")}
+            className="text-sm text-muted-foreground underline"
+          >
+            Build an Avatar
+          </button>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- scaffold function for future Stable Diffusion integration
- add Avatar generator page with form and preview
- register new avatar route and home link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 4 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689add7d61488330a05c72de03ca1eb7