### PR TITLE
Add settings modal with user preference toggles

### DIFF
--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import type { Scenario } from "@/types";
+import type { Scenario, Settings } from "@/types";
 import { usePersonas } from "@/hooks/usePersonas";
 import NPCAvatar from "./NPCAvatar";
 import TrolleyDiagram from "./TrolleyDiagram";
@@ -7,9 +7,10 @@ import TrolleyDiagram from "./TrolleyDiagram";
 interface ScenarioCardProps {
   scenario: Scenario;
   onPick: (choice: "A" | "B") => void;
+  settings: Settings;
 }
 
-const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
+const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick, settings }) => {
   const [showNPC, setShowNPC] = useState(false);
   const { personas } = usePersonas();
 
@@ -31,6 +32,26 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
     }));
   }, [scenario, personas]);
 
+  function handlePick(choice: "A" | "B") {
+    if (settings.sound) {
+      try {
+        const ctx = new AudioContext();
+        const osc = ctx.createOscillator();
+        osc.type = "sine";
+        osc.frequency.value = 440;
+        osc.connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.1);
+      } catch {
+        /* ignore */
+      }
+    }
+    if (settings.haptics && "vibrate" in navigator) {
+      navigator.vibrate(100);
+    }
+    onPick(choice);
+  }
+
   return (
     <article className="space-y-6">
       <header className="space-y-2">
@@ -45,25 +66,33 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
 
       {/* Trolley Diagram */}
       <div className="py-4">
-        <TrolleyDiagram 
-          trackALabel="A" 
+        <TrolleyDiagram
+          trackALabel="A"
           trackBLabel="B"
-          className="animate-fade-in"
+          className={settings.animations ? "animate-fade-in" : undefined}
         />
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <button
-          className="group w-full py-4 px-4 rounded-lg border border-border bg-card hover:bg-[hsl(var(--choice-hover))] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring text-left transform hover:scale-[1.02] active:scale-[0.98]"
-          onClick={() => onPick("A")}
+          className={`group w-full py-4 px-4 rounded-lg border border-border bg-card hover:bg-[hsl(var(--choice-hover))] focus:outline-none focus:ring-2 focus:ring-ring text-left ${
+            settings.animations
+              ? "transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98]"
+              : ""
+          }`}
+          onClick={() => handlePick("A")}
           aria-label="Choose Track A"
         >
           <div className="font-semibold mb-2 text-primary group-hover:text-primary/90">Track A</div>
           <div className="text-sm text-muted-foreground group-hover:text-foreground/80">{scenario.track_a}</div>
         </button>
         <button
-          className="group w-full py-4 px-4 rounded-lg border border-border bg-card hover:bg-[hsl(var(--choice-hover))] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring text-left transform hover:scale-[1.02] active:scale-[0.98]"
-          onClick={() => onPick("B")}
+          className={`group w-full py-4 px-4 rounded-lg border border-border bg-card hover:bg-[hsl(var(--choice-hover))] focus:outline-none focus:ring-2 focus:ring-ring text-left ${
+            settings.animations
+              ? "transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98]"
+              : ""
+          }`}
+          onClick={() => handlePick("B")}
           aria-label="Choose Track B"
         >
           <div className="font-semibold mb-2 text-primary group-hover:text-primary/90">Track B</div>
@@ -81,10 +110,10 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
             {showNPC ? "Hide" : "See"} sample NPC takes
           </button>
           {showNPC && (
-            <div className="mt-4 space-y-3 animate-fade-in">
+            <div className={`mt-4 space-y-3 ${settings.animations ? "animate-fade-in" : ""}`}>
               {samples.map((r, i) => (
                 <div key={i} className="flex items-start gap-3 p-4 rounded-lg bg-[hsl(var(--npc-bg))] border border-border/50">
-                  <NPCAvatar 
+                  <NPCAvatar
                     name={r.avatar ?? "NPC"} 
                     size="md"
                     className="mt-0.5"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,51 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Settings as SettingsIcon } from "lucide-react";
+import type { Settings } from "@/types";
+import React from "react";
+
+interface SettingsModalProps {
+  settings: Settings;
+  onChange: (value: Settings) => void;
+}
+
+const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onChange }) => {
+  const toggle = (key: keyof Settings) => (checked: boolean) => {
+    onChange({ ...settings, [key]: checked });
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          aria-label="Settings"
+          className="p-2 rounded-full hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <SettingsIcon className="h-5 w-5" />
+        </button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="sound">Sound</Label>
+            <Switch id="sound" checked={settings.sound} onCheckedChange={toggle("sound")} />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="haptics">Haptics</Label>
+            <Switch id="haptics" checked={settings.haptics} onCheckedChange={toggle("haptics")} />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="animations">Animations</Label>
+            <Switch id="animations" checked={settings.animations} onCheckedChange={toggle("animations")} />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SettingsModal;

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -2,9 +2,10 @@ import { useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Progress from "@/components/Progress";
 import ScenarioCard from "@/components/ScenarioCard";
+import SettingsModal from "@/components/SettingsModal";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useScenarios } from "@/hooks/useScenarios";
-import type { Scenario } from "@/types";
+import type { Scenario, Settings } from "@/types";
 import type { Choice } from "@/utils/scoring";
 
 const ANSWERS_KEY = "trolleyd-answers";
@@ -14,6 +15,11 @@ const Play = () => {
   const navigate = useNavigate();
   const { scenarios, loading } = useScenarios();
   const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+  const [settings, setSettings] = useLocalStorage<Settings>("trolleyd-settings", {
+    sound: true,
+    haptics: true,
+    animations: true,
+  });
   const [params] = useSearchParams();
 
   const index = useMemo(() => {
@@ -90,12 +96,15 @@ const Play = () => {
           <div className="text-sm text-muted-foreground font-medium">
             Question {index + 1} of {total}
           </div>
-          <button 
-            onClick={() => navigate("/results")} 
-            className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
-          >
-            End & See Results
-          </button>
+          <div className="flex items-center gap-2">
+            <SettingsModal settings={settings} onChange={setSettings} />
+            <button
+              onClick={() => navigate("/results")}
+              className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+            >
+              End & See Results
+            </button>
+          </div>
         </div>
         <div className="space-y-2">
           <div className="h-2 animate-scale-in">
@@ -110,7 +119,7 @@ const Play = () => {
       </section>
 
       {s && (
-        <ScenarioCard scenario={s} onPick={pick} />
+        <ScenarioCard scenario={s} onPick={pick} settings={settings} />
       )}
 
       <div className="flex items-center justify-between pt-4">

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,9 @@ export interface Scenario {
     rationale?: string;
   }>;
 }
+
+export interface Settings {
+  sound: boolean;
+  haptics: boolean;
+  animations: boolean;
+}


### PR DESCRIPTION
## Summary
- add accessible settings modal with switches for sound, haptics, and animations
- persist user preferences in local storage and consume in ScenarioCard
- include gear icon on play screen to launch modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interface no members, unexpected any, no-require-imports)*
- `npx eslint src/components/SettingsModal.tsx src/components/ScenarioCard.tsx src/pages/Play.tsx src/types.ts`


------
https://chatgpt.com/codex/tasks/task_e_689adc3a2d808330a0bbe3202cdb563e