### PR TITLE
Add accessibility CI checks and documentation

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test:a11y

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Thank you for taking the time to contribute! To keep the project accessible, please use the automated and manual checks below before submitting changes.
+
+## Manual accessibility testing
+
+### Keyboard-only navigation
+1. Use `Tab` and `Shift+Tab` to move through all interactive elements.
+2. Ensure a visible focus indicator is present and focus is never trapped.
+3. Activate links or buttons with `Enter` or `Space` to confirm they work without a mouse.
+
+### Screen reader usage
+1. Start a screen reader such as VoiceOver, NVDA, or JAWS.
+2. Navigate through the interface and confirm that important content is announced in a logical order.
+3. Verify that headings, landmarks, and alternative text provide the necessary context.
+4. Report any issues using the "Report accessibility issue" link in the footer.
+
+## Automated checks
+
+Run the lint and accessibility tests:
+
+```sh
+npm run lint
+npm run test:a11y
+```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:a11y": "npm run build && npx @axe-core/cli \"file://$(pwd)/dist/index.html\" --exit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import Play from "./pages/Play";
 import Results from "./pages/Results";
 import NotFound from "./pages/NotFound";
+import Footer from "@/components/Footer";
 
 const queryClient = new QueryClient();
 
@@ -23,6 +24,7 @@ const App = () => (
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
+        <Footer />
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,12 @@
+const Footer = () => (
+  <footer className="text-center p-4 text-sm text-muted-foreground">
+    <a
+      href="https://github.com/trolley-d-game/trolley-d-game/issues/new?labels=accessibility"
+      className="underline"
+    >
+      Report accessibility issue
+    </a>
+  </footer>
+);
+
+export default Footer;


### PR DESCRIPTION
## Summary
- run axe-core accessibility scan during CI
- document keyboard and screen reader testing steps
- add footer link to report accessibility issues

## Testing
- `npm run lint` *(fails: 4 errors, 7 warnings)*
- `npm run test:a11y` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@axe-core%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_689adc47a0d483308a621a2528ae7af2