### PR TITLE
feat: add axis metadata and scoring

### DIFF
--- a/data/scenarios.json
+++ b/data/scenarios.json
@@ -7,6 +7,10 @@
     "track_b": "Do nothing (kill 5, save 1)",
     "theme": "Utilitarian vs. Deontological Ethics",
     "tags": ["classic", "numbers", "action_vs_inaction"],
+    "axes": {
+      "orderChaos": { "A": 1, "B": -1 },
+      "mercyMischief": { "A": 1, "B": -1 }
+    },
     "responses": [
       {
         "avatar": "Socrates",
@@ -28,6 +32,10 @@
     "track_b": "Save the engine room (5 passengers)",
     "theme": "Identity vs. Utility",
     "tags": ["identity", "numbers", "preservation"],
+    "axes": {
+      "orderChaos": { "A": 1, "B": -1 },
+      "materialSocial": { "A": -1, "B": 1 }
+    },
     "responses": [
       {
         "avatar": "Aristotle",
@@ -49,6 +57,10 @@
     "track_b": "Swerve (hit young jaywalker)",
     "theme": "Legal vs. Utilitarian Calculation",
     "tags": ["modern", "age", "law", "technology"],
+    "axes": {
+      "orderChaos": { "A": 1, "B": -1 },
+      "mercyMischief": { "A": 1, "B": -1 }
+    },
     "responses": [
       {
         "avatar": "Rawls",
@@ -70,6 +82,11 @@
     "track_b": "Let nature take its course (5 die, 1 lives)",
     "theme": "Active vs. Passive Harm",
     "tags": ["medical", "active_harm", "numbers"],
+    "axes": {
+      "orderChaos": { "A": -1, "B": 1 },
+      "materialSocial": { "A": 1, "B": -1 },
+      "mercyMischief": { "A": -1, "B": 1 }
+    },
     "responses": [
       {
         "avatar": "Hippocrates",
@@ -91,6 +108,11 @@
     "track_b": "Allow disaster (1000 die, 100 exist)",
     "theme": "Temporal Ethics and Existence",
     "tags": ["time_travel", "existence", "large_numbers"],
+    "axes": {
+      "orderChaos": { "A": -1, "B": 1 },
+      "materialSocial": { "A": 1, "B": -1 },
+      "mercyMischief": { "A": 1, "B": -1 }
+    },
     "responses": [
       {
         "avatar": "Parfit",

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -4,7 +4,7 @@ import AxisVisualization from "@/components/AxisVisualization";
 import TrolleyDiagram from "@/components/TrolleyDiagram";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useScenarios } from "@/hooks/useScenarios";
-import { Choice, computeAxes_legacy as computeAxes, computeBaseCounts } from "@/utils/scoring";
+import { Choice, computeAxes, computeBaseCounts } from "@/utils/scoring";
 
 const ANSWERS_KEY = "trolleyd-answers";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,12 @@ export interface Scenario {
   track_b: string;
   theme?: string;
   tags?: string[];
+  axes?: Partial<Record<AxisName, { A?: number; B?: number }>>;
   responses?: Array<{
     avatar: string;
     choice: "A" | "B";
     rationale?: string;
   }>;
 }
+
+export type AxisName = "orderChaos" | "materialSocial" | "mercyMischief";

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -1,6 +1,8 @@
-import type { Scenario } from "@/types";
+import type { Scenario, AxisName } from "@/types";
 
-export function countAB(answers: Record<string, "A"|"B"|"skip">) {
+export type Choice = "A" | "B" | "skip";
+
+export function countAB(answers: Record<string, Choice>) {
   return Object.values(answers).reduce(
     (acc, v) => {
       if (v === "A") acc.A += 1;
@@ -11,51 +13,37 @@ export function countAB(answers: Record<string, "A"|"B"|"skip">) {
   );
 }
 
-const ORDER = new Set(["bureaucracy", "standards", "logistics"]);
-const CHAOS = new Set(["absurd", "paradox", "infinite"]);
-const MATERIAL = new Set(["reality", "manufacturing_defects", "quality_control", "space"]);
-const SOCIAL = new Set(["identity", "meaning", "workers_rights", "existential"]);
-
-const MISCHIEF_WORDS = ["hit", "tow", "deny", "erase", "confine", "condemn", "break"];
-
-export function computeAxes(
-  answers: Record<string, "A"|"B"|"skip">,
-  scenarios: Scenario[]
-) {
-  let order = 0, chaos = 0, material = 0, social = 0, mercy = 0, mischief = 0;
-
-  for (const s of scenarios) {
-    // Order/Chaos from tags
-    if (s.tags?.some(t => ORDER.has(t))) order++;
-    if (s.tags?.some(t => CHAOS.has(t))) chaos++;
-    if (s.tags?.some(t => MATERIAL.has(t))) material++;
-    if (s.tags?.some(t => SOCIAL.has(t))) social++;
-
-    const pick = answers[s.id];
-    if (!pick || pick === "skip") continue;
-
-    const text = (pick === "A" ? s.track_a : s.track_b).toLowerCase();
-    const isMischief = MISCHIEF_WORDS.some(w => text.includes(w));
-    if (isMischief) mischief++; else mercy++;
-  }
-
-  return { order, chaos, material, social, mercy, mischief };
-}
-
-// Legacy compatibility functions
-export type Choice = "A" | "B" | "skip";
-
 export function computeBaseCounts(answers: Record<string, Choice>) {
   const counts = countAB(answers);
   return { scoreA: counts.A, scoreB: counts.B };
 }
 
-export function computeAxes_legacy(scenarios: Scenario[], answers: Record<string, Choice>) {
-  const raw = computeAxes(answers, scenarios);
+export function computeAxes(
+  scenarios: Scenario[],
+  answers: Record<string, Choice>
+) {
+  const totals: Record<AxisName, number> = {
+    orderChaos: 0,
+    materialSocial: 0,
+    mercyMischief: 0,
+  };
+
+  for (const s of scenarios) {
+    const pick = answers[s.id];
+    if (!pick || pick === "skip" || !s.axes) continue;
+    for (const [axis, values] of Object.entries(s.axes)) {
+      const delta = values[pick as "A" | "B"];
+      if (typeof delta === "number") {
+        totals[axis as AxisName] += delta;
+      }
+    }
+  }
+
   const clamp = (n: number) => Math.max(-10, Math.min(10, n));
   return {
-    orderChaos: clamp(raw.order - raw.chaos),
-    materialSocial: clamp(raw.material - raw.social),
-    mercyMischief: clamp(raw.mercy - raw.mischief),
+    orderChaos: clamp(totals.orderChaos),
+    materialSocial: clamp(totals.materialSocial),
+    mercyMischief: clamp(totals.mercyMischief),
   };
 }
+


### PR DESCRIPTION
## Summary
- add axes to scenarios and expose axis types
- compute axis scores from scenario metadata
- use new axis scoring on results page

## Testing
- `npm run lint` (fails: no-empty-object-type, no-explicit-any, no-require-imports)
- `bun --eval "import { computeAxes } from './src/utils/scoring.ts'; import scenarios from './data/scenarios.json'; const ans={EN01:'A',EN02:'B',EN03:'A',EN04:'B',EN05:'A'}; console.log(computeAxes(scenarios, ans));"`
- `bun --eval "import { computeAxes } from './src/utils/scoring.ts'; import scenarios from './data/scenarios.json'; const ans={EN01:'B',EN02:'A',EN03:'B',EN04:'A',EN05:'B'}; console.log(computeAxes(scenarios, ans));"`


------
https://chatgpt.com/codex/tasks/task_e_689b82514e7483309717c66c7fd0cf7f