### PR TITLE
feat: share game results

### DIFF
--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -4,6 +4,8 @@ import AxisVisualization from "@/components/AxisVisualization";
 import TrolleyDiagram from "@/components/TrolleyDiagram";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useScenarios } from "@/hooks/useScenarios";
+import { toast } from "@/components/ui/use-toast";
+import { shareResults } from "@/utils/share";
 import { Choice, computeAxes_legacy as computeAxes, computeBaseCounts } from "@/utils/scoring";
 
 const ANSWERS_KEY = "trolleyd-answers";
@@ -16,6 +18,14 @@ const Results = () => {
 
   const { scoreA, scoreB } = useMemo(() => computeBaseCounts(answers), [answers]);
   const axes = useMemo(() => computeAxes(scenarios ?? [], answers), [scenarios, answers]);
+
+  const handleShare = async () => {
+    const result = await shareResults(scoreA, scoreB);
+    toast({
+      description:
+        result === "shared" ? "Share dialog opened" : "Results copied to clipboard",
+    });
+  };
 
   if (!scenarios) return (
     <main className="min-h-screen container py-10" />
@@ -54,6 +64,10 @@ const Results = () => {
               onClick={() => navigate("/play")}
               className="flex-1 px-4 py-2 rounded-lg border border-border bg-card hover:bg-accent transition-all duration-200 font-medium"
             >Play Again</button>
+            <button
+              onClick={handleShare}
+              className="flex-1 px-4 py-2 rounded-lg border border-border bg-card hover:bg-accent transition-all duration-200 font-medium"
+            >Share Results</button>
           </div>
         </article>
 

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,0 +1,18 @@
+export function constructShareText(scoreA: number, scoreB: number) {
+  const url = window.location.origin;
+  return `I scored Track A ${scoreA} vs Track B ${scoreB} in Trolley’d! Play here: ${url}`;
+}
+
+export async function shareResults(scoreA: number, scoreB: number) {
+  const text = constructShareText(scoreA, scoreB);
+  const url = window.location.origin;
+  if (navigator.share) {
+    await navigator.share({ text, url });
+    return "shared" as const;
+  }
+
+  await navigator.clipboard.writeText(`${text}`);
+  const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`;
+  window.open(twitterUrl, "_blank", "noopener,noreferrer");
+  return "copied" as const;
+}


### PR DESCRIPTION
## Summary
- add utility to build shareable results text and copy/share
- add share button with toast feedback on results page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 4 errors, 7 warnings)
- `npx eslint src/pages/Results.tsx src/utils/share.ts && echo "lint passed"`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689add7e4b10833092a92bd4031e6e09