### PR TITLE
feat: add save slots for multiple runs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import Play from "./pages/Play";
 import Results from "./pages/Results";
 import NotFound from "./pages/NotFound";
+import SaveSlots from "./pages/SaveSlots";
 
 const queryClient = new QueryClient();
 
@@ -15,15 +16,16 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/play" element={<Play />} />
-          <Route path="/results" element={<Results />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/slots" element={<SaveSlots />} />
+            <Route path="/play" element={<Play />} />
+            <Route path="/results" element={<Results />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -23,13 +23,13 @@ const Index = () => {
           />
         </div>
         
-        <button
-          onClick={() => navigate("/play")}
-          className="px-8 py-4 rounded-lg border border-border bg-card hover:bg-accent transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring transform hover:scale-105 active:scale-95 font-medium text-lg"
-          aria-label="Start playing Trolley'd"
-        >
-          Begin Your Journey
-        </button>
+          <button
+            onClick={() => navigate("/slots")}
+            className="px-8 py-4 rounded-lg border border-border bg-card hover:bg-accent transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring transform hover:scale-105 active:scale-95 font-medium text-lg"
+            aria-label="Start playing Trolley'd"
+          >
+            Begin Your Journey
+          </button>
       </div>
     </main>
   );

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -8,13 +8,20 @@ import type { Scenario } from "@/types";
 import type { Choice } from "@/utils/scoring";
 
 const ANSWERS_KEY = "trolleyd-answers";
+const SLOT_KEY = "trolleyd-current-slot";
 
 const Play = () => {
   useEffect(() => { document.title = "Trolley’d · Play"; }, []);
   const navigate = useNavigate();
   const { scenarios, loading } = useScenarios();
-  const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+  const [slot] = useLocalStorage<string | null>(SLOT_KEY, null);
+  const answerKey = slot ? `${slot}-${ANSWERS_KEY}` : ANSWERS_KEY;
+  const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(answerKey, {});
   const [params] = useSearchParams();
+
+  useEffect(() => {
+    if (!slot) navigate("/slots");
+  }, [slot, navigate]);
 
   const index = useMemo(() => {
     if (!scenarios) return 0;

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -7,15 +7,22 @@ import { useScenarios } from "@/hooks/useScenarios";
 import { Choice, computeAxes_legacy as computeAxes, computeBaseCounts } from "@/utils/scoring";
 
 const ANSWERS_KEY = "trolleyd-answers";
+const SLOT_KEY = "trolleyd-current-slot";
 
 const Results = () => {
   useEffect(() => { document.title = "Trolley’d · Results"; }, []);
   const navigate = useNavigate();
   const { scenarios } = useScenarios();
-  const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+  const [slot] = useLocalStorage<string | null>(SLOT_KEY, null);
+  const answerKey = slot ? `${slot}-${ANSWERS_KEY}` : ANSWERS_KEY;
+  const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(answerKey, {});
 
   const { scoreA, scoreB } = useMemo(() => computeBaseCounts(answers), [answers]);
   const axes = useMemo(() => computeAxes(scenarios ?? [], answers), [scenarios, answers]);
+
+  useEffect(() => {
+    if (!slot) navigate("/slots");
+  }, [slot, navigate]);
 
   if (!scenarios) return (
     <main className="min-h-screen container py-10" />
@@ -97,7 +104,7 @@ const Results = () => {
         </ul>
         <div className="mt-4 flex gap-2">
           <button
-            onClick={() => { localStorage.removeItem(ANSWERS_KEY); setAnswers({}); navigate("/play"); }}
+            onClick={() => { localStorage.removeItem(answerKey); setAnswers({}); navigate("/play"); }}
             className="px-4 py-2 rounded-md border border-border hover:bg-accent"
           >Reset game</button>
         </div>

--- a/src/pages/SaveSlots.tsx
+++ b/src/pages/SaveSlots.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+
+interface Slot { id: string; name: string }
+
+const SLOTS_KEY = "trolleyd-slots";
+const CURRENT_SLOT_KEY = "trolleyd-current-slot";
+const ANSWERS_KEY = "trolleyd-answers";
+
+const SaveSlots = () => {
+  useEffect(() => { document.title = "Trolley'd · Save Slots"; }, []);
+  const navigate = useNavigate();
+  const [slots, setSlots] = useLocalStorage<Slot[]>(SLOTS_KEY, []);
+  const [currentSlot, setCurrentSlot] = useLocalStorage<string | null>(CURRENT_SLOT_KEY, null);
+
+  function selectSlot(id: string) {
+    setCurrentSlot(id);
+    navigate("/play");
+  }
+
+  function newGame() {
+    const name = window.prompt("Name for new game", `Slot ${slots.length + 1}`);
+    if (!name) return;
+    const id = crypto.randomUUID();
+    const newSlots = [...slots, { id, name }];
+    setSlots(newSlots);
+    setCurrentSlot(id);
+    navigate("/play");
+  }
+
+  function deleteSlot(id: string) {
+    const remaining = slots.filter(s => s.id !== id);
+    setSlots(remaining);
+    localStorage.removeItem(`${id}-${ANSWERS_KEY}`);
+    if (currentSlot === id) {
+      setCurrentSlot(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen container max-w-md py-8 space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold">Select Save Slot</h1>
+      </header>
+      <ul className="space-y-2">
+        {slots.map(s => (
+          <li key={s.id} className="flex items-center justify-between border border-border rounded-md p-3">
+            <button onClick={() => selectSlot(s.id)} className="text-left flex-1">
+              {s.name}
+            </button>
+            <button onClick={() => deleteSlot(s.id)} className="text-xs text-destructive ml-2">
+              Delete
+            </button>
+          </li>
+        ))}
+        {slots.length === 0 && (
+          <li className="text-muted-foreground">No save slots.</li>
+        )}
+      </ul>
+      <button
+        onClick={newGame}
+        className="px-4 py-2 rounded-lg border border-border bg-card hover:bg-accent transition-colors font-medium"
+      >
+        New Game
+      </button>
+    </main>
+  );
+};
+
+export default SaveSlots;
+


### PR DESCRIPTION
## Summary
- add SaveSlots page for selecting, creating or deleting save slots
- prefix stored answers with the active slot ID and support dynamic keys
- wire up routing to the new start screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ada78e7d0833080d506dfc8914cb2