### PR TITLE
Add lever control for scenario choices

### DIFF
--- a/src/components/Lever.tsx
+++ b/src/components/Lever.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+
+interface LeverProps {
+  onChange?: (direction: "up" | "down") => void;
+  className?: string;
+}
+
+const Lever: React.FC<LeverProps> = ({ onChange, className = "" }) => {
+  const [position, setPosition] = useState<"up" | "down">("down");
+
+  function move(dir: "up" | "down") {
+    setPosition(dir);
+    onChange?.(dir);
+  }
+
+  return (
+    <div
+      className={`flex flex-col items-center ${className}`}
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.key === "ArrowUp") move("up");
+        if (e.key === "ArrowDown") move("down");
+      }}
+    >
+      <div className="relative h-40 w-4 bg-muted rounded" onClick={e => {
+        const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+        const y = e.clientY - rect.top;
+        if (y < rect.height / 2) move("up");
+        else move("down");
+      }}>
+        <div
+          className="absolute left-1/2 -translate-x-1/2 w-6 h-6 rounded-full bg-primary shadow transition-all duration-200"
+          style={{ top: position === "up" ? "0.25rem" : "calc(100% - 2.25rem)" }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Lever;

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -3,6 +3,7 @@ import type { Scenario } from "@/types";
 import { usePersonas } from "@/hooks/usePersonas";
 import NPCAvatar from "./NPCAvatar";
 import TrolleyDiagram from "./TrolleyDiagram";
+import Lever from "./Lever";
 
 interface ScenarioCardProps {
   scenario: Scenario;
@@ -12,6 +13,7 @@ interface ScenarioCardProps {
 const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
   const [showNPC, setShowNPC] = useState(false);
   const { personas } = usePersonas();
+  const [leverPos, setLeverPos] = useState<"up" | "down" | null>(null);
 
   const samples = useMemo(() => {
     const r = scenario.responses ?? [];
@@ -45,30 +47,32 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick }) => {
 
       {/* Trolley Diagram */}
       <div className="py-4">
-        <TrolleyDiagram 
-          trackALabel="A" 
+        <TrolleyDiagram
+          trackALabel="A"
           trackBLabel="B"
           className="animate-fade-in"
+          choice={leverPos == null ? undefined : leverPos === "up" ? "A" : "B"}
         />
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <button
-          className="group w-full py-4 px-4 rounded-lg border border-border bg-card hover:bg-[hsl(var(--choice-hover))] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring text-left transform hover:scale-[1.02] active:scale-[0.98]"
-          onClick={() => onPick("A")}
-          aria-label="Choose Track A"
-        >
-          <div className="font-semibold mb-2 text-primary group-hover:text-primary/90">Track A</div>
-          <div className="text-sm text-muted-foreground group-hover:text-foreground/80">{scenario.track_a}</div>
-        </button>
-        <button
-          className="group w-full py-4 px-4 rounded-lg border border-border bg-card hover:bg-[hsl(var(--choice-hover))] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring text-left transform hover:scale-[1.02] active:scale-[0.98]"
-          onClick={() => onPick("B")}
-          aria-label="Choose Track B"
-        >
-          <div className="font-semibold mb-2 text-primary group-hover:text-primary/90">Track B</div>
-          <div className="text-sm text-muted-foreground group-hover:text-foreground/80">{scenario.track_b}</div>
-        </button>
+        <div className="w-full py-4 px-4 rounded-lg border border-border bg-card text-left">
+          <div className="font-semibold mb-2 text-primary">Track A</div>
+          <div className="text-sm text-muted-foreground">{scenario.track_a}</div>
+        </div>
+        <div className="w-full py-4 px-4 rounded-lg border border-border bg-card text-left">
+          <div className="font-semibold mb-2 text-primary">Track B</div>
+          <div className="text-sm text-muted-foreground">{scenario.track_b}</div>
+        </div>
+      </div>
+
+      <div className="flex justify-center pt-4">
+        <Lever
+          onChange={(dir) => {
+            setLeverPos(dir);
+            onPick(dir === "up" ? "A" : "B");
+          }}
+        />
       </div>
 
       {samples.length > 0 && (

--- a/src/components/TrolleyDiagram.tsx
+++ b/src/components/TrolleyDiagram.tsx
@@ -4,17 +4,21 @@ interface TrolleyDiagramProps {
   trackALabel?: string;
   trackBLabel?: string;
   className?: string;
+  choice?: "A" | "B";
 }
 
-const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({ 
-  trackALabel = "Track A", 
+const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({
+  trackALabel = "Track A",
   trackBLabel = "Track B",
-  className = ""
+  className = "",
+  choice,
 }) => {
+  const leverY = choice === "A" ? 70 : choice === "B" ? 130 : 100;
+
   return (
     <div className={`w-full max-w-md mx-auto ${className}`}>
-      <svg 
-        viewBox="0 0 300 200" 
+      <svg
+        viewBox="0 0 300 200"
         className="w-full h-auto"
         role="img"
         aria-label="Trolley track diagram showing choice between two paths"
@@ -26,7 +30,7 @@ const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({
           strokeWidth="4"
           fill="none"
         />
-        
+
         {/* Track fork - A (top) */}
         <path
           d="M120 100 L200 60"
@@ -34,7 +38,7 @@ const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({
           strokeWidth="4"
           fill="none"
         />
-        
+
         {/* Track fork - B (bottom) */}
         <path
           d="M120 100 L200 140"
@@ -42,7 +46,26 @@ const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({
           strokeWidth="4"
           fill="none"
         />
-        
+
+        {/* Lever */}
+        <line
+          x1="120"
+          y1="100"
+          x2="120"
+          y2={leverY}
+          stroke="hsl(var(--trolley-track))"
+          strokeWidth="4"
+          strokeLinecap="round"
+        />
+        <circle
+          cx="120"
+          cy={leverY}
+          r="6"
+          fill="hsl(var(--trolley-body))"
+          stroke="hsl(var(--trolley-track))"
+          strokeWidth="2"
+        />
+
         {/* Trolley */}
         <g className="animate-trolley-move">
           <rect
@@ -57,7 +80,7 @@ const TrolleyDiagram: React.FC<TrolleyDiagramProps> = ({
           <circle cx="48" cy="116" r="4" fill="hsl(var(--trolley-track))" />
           <circle cx="64" cy="116" r="4" fill="hsl(var(--trolley-track))" />
         </g>
-        
+
         {/* Track labels */}
         <text
           x="200"

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -30,8 +30,8 @@ const Play = () => {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") { pick("A"); }
-      if (e.key === "ArrowRight") { pick("B"); }
+      if (e.key === "ArrowUp") { pick("A"); }
+      if (e.key === "ArrowDown") { pick("B"); }
       if (e.key.toLowerCase() === "s") { skip(); }
     };
     window.addEventListener("keydown", onKey);
@@ -121,7 +121,7 @@ const Play = () => {
           Skip this scenario
         </button>
         <div className="text-xs text-muted-foreground bg-muted/50 px-3 py-1 rounded-full">
-          Shortcuts: ← A · → B · S Skip
+          Shortcuts: ↑ A · ↓ B · S Skip
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- add reusable Lever component that emits `up`/`down`
- replace scenario buttons with Lever and update diagram
- update keyboard shortcuts to match lever orientation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ada719af083308766f399d7faa376