### PR TITLE
feat: add scorecard and friend data import

### DIFF
--- a/src/components/Scorecard.tsx
+++ b/src/components/Scorecard.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface ScorecardProps {
+  name: string;
+  scoreA: number;
+  scoreB: number;
+}
+
+const Scorecard: React.FC<ScorecardProps> = ({ name, scoreA, scoreB }) => {
+  return (
+    <div>
+      <h3 className="font-semibold mb-2">{name}</h3>
+      <div className="grid grid-cols-2 gap-4 text-center">
+        <div className="p-4 rounded-lg bg-gradient-to-br from-primary/5 to-primary/10 border border-primary/20">
+          <div className="text-xs text-muted-foreground uppercase tracking-wide">Track A</div>
+          <div className="text-3xl font-bold text-primary mt-1">{scoreA}</div>
+        </div>
+        <div className="p-4 rounded-lg bg-gradient-to-br from-secondary/5 to-secondary/10 border border-secondary/20">
+          <div className="text-xs text-muted-foreground uppercase tracking-wide">Track B</div>
+          <div className="text-3xl font-bold text-secondary-foreground mt-1">{scoreB}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Scorecard;

--- a/src/hooks/useFriends.ts
+++ b/src/hooks/useFriends.ts
@@ -1,0 +1,41 @@
+import { useLocalStorage } from "./useLocalStorage";
+import { computeBaseCounts, Choice } from "@/utils/scoring";
+import { useScores } from "./useScores";
+
+export interface FriendData {
+  name: string;
+  answers: Record<string, Choice>;
+}
+
+const FRIENDS_KEY = "trolleyd-friends";
+
+export function useFriends() {
+  const [friends, setFriends] = useLocalStorage<FriendData[]>(FRIENDS_KEY, []);
+  const [scores, setScores] = useScores();
+
+  function importFriend(json: string) {
+    try {
+      const parsed = JSON.parse(json) as FriendData | FriendData[];
+      const arr = Array.isArray(parsed) ? parsed : [parsed];
+      const valid = arr.filter(
+        (f): f is FriendData =>
+          f && typeof f.name === "string" && typeof f.answers === "object"
+      );
+      if (valid.length === 0) return;
+
+      const newFriends = [...friends, ...valid];
+      setFriends(newFriends);
+
+      const newScores = { ...scores };
+      valid.forEach((f) => {
+        const { scoreA, scoreB } = computeBaseCounts(f.answers);
+        newScores[f.name] = { scoreA, scoreB };
+      });
+      setScores(newScores);
+    } catch {
+      // invalid json; ignore
+    }
+  }
+
+  return { friends, importFriend };
+}

--- a/src/hooks/useScores.ts
+++ b/src/hooks/useScores.ts
@@ -1,0 +1,14 @@
+import { useLocalStorage } from "./useLocalStorage";
+
+export interface Score {
+  scoreA: number;
+  scoreB: number;
+}
+
+export type Scores = Record<string, Score>;
+
+export const SCORES_KEY = "trolleyd-scores";
+
+export function useScores() {
+  return useLocalStorage<Scores>(SCORES_KEY, {});
+}

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -4,16 +4,19 @@ import Progress from "@/components/Progress";
 import ScenarioCard from "@/components/ScenarioCard";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useScenarios } from "@/hooks/useScenarios";
+import { useScores } from "@/hooks/useScores";
 import type { Scenario } from "@/types";
-import type { Choice } from "@/utils/scoring";
+import { Choice, computeBaseCounts } from "@/utils/scoring";
 
 const ANSWERS_KEY = "trolleyd-answers";
+const PLAYER_NAME = "You";
 
 const Play = () => {
   useEffect(() => { document.title = "Trolley’d · Play"; }, []);
   const navigate = useNavigate();
   const { scenarios, loading } = useScenarios();
   const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+  const [scores, setScores] = useScores();
   const [params] = useSearchParams();
 
   const index = useMemo(() => {
@@ -73,13 +76,19 @@ const Play = () => {
 
   function pick(choice: "A" | "B") {
     if (!s) return;
-    setAnswers({ ...answers, [s.id]: choice });
+    const updated = { ...answers, [s.id]: choice };
+    setAnswers(updated);
+    const { scoreA, scoreB } = computeBaseCounts(updated);
+    setScores({ ...scores, [PLAYER_NAME]: { scoreA, scoreB } });
     advance();
   }
 
   function skip() {
     if (!s) return;
-    setAnswers({ ...answers, [s.id]: "skip" });
+    const updated = { ...answers, [s.id]: "skip" };
+    setAnswers(updated);
+    const { scoreA, scoreB } = computeBaseCounts(updated);
+    setScores({ ...scores, [PLAYER_NAME]: { scoreA, scoreB } });
     advance();
   }
 


### PR DESCRIPTION
## Summary
- add reusable Scorecard component
- track and store competitor scores, including friend imports
- show scorecard and competitor switcher on results screen

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*
- `npx eslint src/components/Scorecard.tsx src/hooks/useScores.ts src/hooks/useFriends.ts src/pages/Play.tsx src/pages/Results.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ada755a808330b2f67919a509602e