### PR TITLE
feat: surface community choice stats

### DIFF
--- a/src/hooks/useAnswers.ts
+++ b/src/hooks/useAnswers.ts
@@ -1,0 +1,9 @@
+import { useLocalStorage } from "./useLocalStorage";
+import type { Choice } from "@/utils/scoring";
+
+const ANSWERS_KEY = "trolleyd-answers";
+
+export function useAnswers() {
+  const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+  return { answers, setAnswers };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,14 @@
+// Base URL for the optional analytics API. When undefined the requests
+// fall back to relative paths which is useful during development or in
+// test environments where the backend may not exist yet.
 export const API_BASE_URL = import.meta.env.VITE_API_URL ?? "";
 
+// Response shape returned from the analytics endpoints. Percentages are in
+// the 0-100 range representing how many players chose option A vs B.
 export interface ScenarioStats {
+  /** Percentage of players who picked option A */
   percentA: number;
+  /** Percentage of players who picked option B */
   percentB: number;
 }
 

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import AxisVisualization from "@/components/AxisVisualization";
 import TrolleyDiagram from "@/components/TrolleyDiagram";
@@ -6,6 +6,7 @@ import InlineError from "@/components/InlineError";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useScenarios } from "@/hooks/useScenarios";
 import { Choice, computeAxes_legacy, computeBaseCounts } from "@/utils/scoring";
+import { fetchOverallStats, type ScenarioStats } from "@/lib/api";
 import { results_viewed } from "@/utils/analytics";
 
 const ANSWERS_KEY = "trolleyd-answers";
@@ -21,6 +22,13 @@ const Results = () => {
   const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
   const { scoreA, scoreB } = useMemo(() => computeBaseCounts(answers), [answers]);
   const axes = useMemo(() => computeAxes_legacy(scenarios ?? [], answers), [scenarios, answers]);
+  const [overallStats, setOverallStats] = useState<ScenarioStats | null>(null);
+
+  useEffect(() => {
+    fetchOverallStats()
+      .then(setOverallStats)
+      .catch(() => {});
+  }, []);
 
   if (error) {
     return (
@@ -49,12 +57,24 @@ const Results = () => {
           <div className="space-y-2">
             <div className="flex justify-between">
               <span>Choice A: {scoreA}</span>
-              <span>{scoreA + scoreB > 0 ? Math.round((scoreA / (scoreA + scoreB)) * 100) : 0}%</span>
+              <span>
+                {scoreA + scoreB > 0 ? Math.round((scoreA / (scoreA + scoreB)) * 100) : 0}%
+              </span>
             </div>
             <div className="flex justify-between">
               <span>Choice B: {scoreB}</span>
-              <span>{scoreA + scoreB > 0 ? Math.round((scoreB / (scoreA + scoreB)) * 100) : 0}%</span>
+              <span>
+                {scoreA + scoreB > 0 ? Math.round((scoreB / (scoreA + scoreB)) * 100) : 0}%
+              </span>
             </div>
+            {overallStats && (
+              <div className="flex justify-between text-sm text-muted-foreground">
+                <span>Global Average</span>
+                <span>
+                  A {Math.round(overallStats.percentA)}% · B {Math.round(overallStats.percentB)}%
+                </span>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,2 +1,19 @@
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+// jsdom doesn't implement matchMedia. Provide a minimal stub so components that
+// query it (e.g. for prefers-reduced-motion) don't crash during tests.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
 


### PR DESCRIPTION
## Summary
- add API helpers for submitting choices and retrieving aggregated stats
- show community choice percentages after answering each scenario
- compare player's choices against global averages on results page

## Testing
- `npm test` *(fails: Play.test.tsx cannot find "skipped 0" and scoring.test.ts expected +0 to be 1)*

------
https://chatgpt.com/codex/tasks/task_e_689c1d75178c8330b5418758461b81ce