### PR TITLE
feat: add generate scenario function with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,17 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Edge Function: generate-scenario
+
+Deploy the function:
+
+```sh
+supabase functions deploy generate-scenario
+```
+
+Invoke it using the Supabase CLI:
+
+```sh
+supabase functions invoke generate-scenario --body '{"seed":"demo","tags":["ethics"],"style":"classic"}'
+```

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,9 @@
 project_id = "aqyrveunmqufurmeikqn"
+
+[functions.generate-scenario]
+verify_jwt = false
+
+[functions.cors]
+allowed_origins = ["*"]
+allowed_headers = ["authorization", "x-client-info", "apikey", "content-type"]
+allowed_methods = ["POST", "OPTIONS"]

--- a/supabase/functions/generate-scenario/deno.json
+++ b/supabase/functions/generate-scenario/deno.json
@@ -1,0 +1,8 @@
+{
+  "tasks": {
+    "start": "deno run --allow-env --allow-net --watch index.ts"
+  },
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/generate-scenario/index.ts
+++ b/supabase/functions/generate-scenario/index.ts
@@ -1,0 +1,76 @@
+import { createClient } from "@supabase/supabase-js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST,OPTIONS",
+};
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { seed, tags = [], style = "" } = await req.json();
+
+    const prompt = `Generate a trolley problem scenario with tags: ${Array.isArray(tags) ? tags.join(", ") : tags} and style: ${style}`;
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+    );
+
+    const { data: cacheData, error: cacheError } = await supabase
+      .from("gen_cache")
+      .select("result")
+      .eq("prompt", prompt)
+      .eq("seed", seed)
+      .maybeSingle();
+
+    if (!cacheError && cacheData) {
+      return new Response(JSON.stringify(cacheData.result), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const apiKey = Deno.env.get("PERPLEXITY_API_KEY");
+    if (!apiKey) {
+      throw new Error("Missing PERPLEXITY_API_KEY");
+    }
+
+    const response = await fetch("https://api.perplexity.ai/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "llama-3.1-sonar-small-128k-online",
+        messages: [
+          { role: "system", content: "You are a scenario generator." },
+          {
+            role: "user",
+            content:
+              `Seed: ${seed}\nTags: ${tags.join(", ")}\nStyle: ${style}\nReturn JSON with fields id,title,description,track_a,track_b,tags.`,
+          },
+        ],
+        response_format: { type: "json_object" },
+      }),
+    });
+
+    const data = await response.json();
+    const scenario = JSON.parse(data.choices[0].message.content);
+
+    await supabase.from("gen_cache").insert({ prompt, seed, result: scenario });
+
+    return new Response(JSON.stringify(scenario), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: String(error) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20250813000000_gen_cache.sql
+++ b/supabase/migrations/20250813000000_gen_cache.sql
@@ -1,0 +1,14 @@
+create table if not exists gen_cache (
+  prompt text,
+  seed text,
+  result jsonb,
+  created_at timestamptz default now(),
+  primary key (prompt, seed)
+);
+
+alter table gen_cache enable row level security;
+
+create policy "Service role access" on gen_cache
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- add `gen_cache` table with RLS limited to service role
- implement `generate-scenario` edge function with Perplexity API caching
- document and configure new function with CORS

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `supabase functions deploy generate-scenario` *(fails: supabase: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2deed5a0833089120e1739aa7521