### PR TITLE
feat: add procedural track images

### DIFF
--- a/src/__tests__/ProceduralTrackImage.test.tsx
+++ b/src/__tests__/ProceduralTrackImage.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import ProceduralTrackImage from '@/components/procedural/ProceduralTrackImage';
+import type { Tag } from '@/types';
+
+test('procedural image is deterministic with seed', () => {
+  const tags: Tag[] = ['logistics', 'identity'];
+  const { container: first } = render(<ProceduralTrackImage tags={tags} seed={1} />);
+  const { container: second } = render(<ProceduralTrackImage tags={tags} seed={1} />);
+  const { container: third } = render(<ProceduralTrackImage tags={tags} seed={2} />);
+  expect(first.innerHTML).toBe(second.innerHTML);
+  expect(first.innerHTML).not.toBe(third.innerHTML);
+});
+
+test('procedural image has accessible role and label', () => {
+  const tags: Tag[] = ['logistics'];
+  const { getByRole } = render(<ProceduralTrackImage tags={tags} />);
+  getByRole('img', { name: /track illustration/i });
+});

--- a/src/__tests__/ScenarioCardImages.test.tsx
+++ b/src/__tests__/ScenarioCardImages.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import ScenarioCard from '@/components/ScenarioCard';
+
+vi.mock('@/hooks/usePersonas', () => ({
+  usePersonas: () => ({ personas: [] })
+}));
+vi.mock('@/hooks/useDecisions', () => ({
+  useDecisions: () => ({ decisions: [] })
+}));
+
+test('renders procedural images for both tracks', () => {
+  const scenario = {
+    id: '1',
+    title: 'Test',
+    track_a: 'Track A desc',
+    track_b: 'Track B desc',
+    tags: ['logistics']
+  } as const;
+  render(<ScenarioCard scenario={scenario} onPick={() => {}} />);
+  const imgs = screen.getAllByRole('img', { name: /track illustration/i });
+  expect(imgs).toHaveLength(2);
+});

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -6,6 +6,7 @@ import { useDecisions } from "@/hooks/useDecisions";
 import NPCAvatar from "./NPCAvatar";
 import InlineError from "./InlineError";
 import { Lever } from "./Lever";
+import ProceduralTrackImage from "./procedural/ProceduralTrackImage";
 import { Slider } from "@/components/ui/slider";
 
 interface ScenarioCardProps {
@@ -99,7 +100,16 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario, onPick, onNext, c
         <p className="text-muted-foreground leading-relaxed">{scenario.description}</p>
       </div>
 
-      {/* Removed TrolleyDiagram pending prop alignment */}
+      <div className="grid grid-cols-2 gap-6 pt-4">
+        <div className="flex flex-col items-center text-center space-y-2">
+          <ProceduralTrackImage tags={scenario.tags ?? []} seed={1} />
+          <p className="text-sm text-muted-foreground">{scenario.track_a}</p>
+        </div>
+        <div className="flex flex-col items-center text-center space-y-2">
+          <ProceduralTrackImage tags={scenario.tags ?? []} seed={2} />
+          <p className="text-sm text-muted-foreground">{scenario.track_b}</p>
+        </div>
+      </div>
 
       {!choice ? (
         <div className="space-y-6">

--- a/src/components/procedural/ProceduralTrackImage.tsx
+++ b/src/components/procedural/ProceduralTrackImage.tsx
@@ -1,0 +1,59 @@
+import React, { useMemo } from "react";
+import type { Tag } from "@/types";
+import { StickFigure, Sign, ObjectPart } from "./parts";
+import { ORDER, SOCIAL } from "@/utils/tags";
+
+interface ProceduralTrackImageProps {
+  tags: Tag[];
+  seed?: number;
+}
+
+const WIDTH = 100;
+const HEIGHT = 40;
+
+function createRng(seed: number) {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = t + Math.imul(t ^ (t >>> 7), 61 | t) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function partForTag(tag: Tag) {
+  if (ORDER.has(tag)) return Sign;
+  if (SOCIAL.has(tag)) return StickFigure;
+  return ObjectPart;
+}
+
+const ProceduralTrackImage: React.FC<ProceduralTrackImageProps> = ({ tags, seed = 1 }) => {
+  const rng = useMemo(() => createRng(seed), [seed]);
+
+  const elements = tags.map((tag, i) => {
+    const Part = partForTag(tag);
+    const x = rng() * (WIDTH - 20) + 10;
+    const y = rng() * (HEIGHT - 20) + 10;
+    return (
+      <g key={i} transform={`translate(${x}, ${y})`}>
+        <Part />
+      </g>
+    );
+  });
+
+  const label = `Track illustration${tags.length ? ` for ${tags.join(", ")}` : ""}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      role="img"
+      aria-label={label}
+      className="text-foreground"
+    >
+      {elements}
+    </svg>
+  );
+};
+
+export default ProceduralTrackImage;

--- a/src/components/procedural/parts/Object.tsx
+++ b/src/components/procedural/parts/Object.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const ObjectPart: React.FC = () => (
+  <g stroke="currentColor" strokeWidth={2}>
+    <circle cx={0} cy={0} r={3} fill="currentColor" />
+  </g>
+);
+
+export default ObjectPart;

--- a/src/components/procedural/parts/Sign.tsx
+++ b/src/components/procedural/parts/Sign.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+const Sign: React.FC = () => (
+  <g stroke="currentColor" strokeWidth={2}>
+    <rect x={-4} y={-3} width={8} height={6} fill="currentColor" />
+    <line x1={0} y1={3} x2={0} y2={8} />
+  </g>
+);
+
+export default Sign;

--- a/src/components/procedural/parts/StickFigure.tsx
+++ b/src/components/procedural/parts/StickFigure.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+const StickFigure: React.FC = () => (
+  <g stroke="currentColor" fill="none" strokeWidth={2}>
+    <circle cx={0} cy={-4} r={2} />
+    <line x1={0} y1={-2} x2={0} y2={4} />
+    <line x1={0} y1={0} x2={-3} y2={2} />
+    <line x1={0} y1={0} x2={3} y2={2} />
+    <line x1={0} y1={4} x2={-3} y2={6} />
+    <line x1={0} y1={4} x2={3} y2={6} />
+  </g>
+);
+
+export default StickFigure;

--- a/src/components/procedural/parts/index.ts
+++ b/src/components/procedural/parts/index.ts
@@ -1,0 +1,3 @@
+export { default as StickFigure } from "./StickFigure";
+export { default as Sign } from "./Sign";
+export { default as ObjectPart } from "./Object";


### PR DESCRIPTION
## Summary
- add procedural SVG parts and composition engine
- render procedural track illustrations in ScenarioCard
- add deterministic and accessibility tests for procedural images

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: No matching version found for tailwind-merge@^2.7.0)*

------
https://chatgpt.com/codex/tasks/task_e_689c2dedb18c83309c6345087c039a25