### PR TITLE
feat: add answer storage with supabase tables

### DIFF
--- a/src/hooks/useAnswers.ts
+++ b/src/hooks/useAnswers.ts
@@ -1,9 +1,59 @@
-import { useLocalStorage } from "./useLocalStorage";
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
 import type { Choice } from "@/utils/scoring";
+import { useLocalStorage } from "./useLocalStorage";
 
 const ANSWERS_KEY = "trolleyd-answers";
 
 export function useAnswers() {
-  const [answers, setAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+  const [answers, setAnswersState] = useState<Record<string, Choice>>({});
+  const [localAnswers, setLocalAnswers] = useLocalStorage<Record<string, Choice>>(ANSWERS_KEY, {});
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (session?.user) {
+        const { data, error } = await supabase
+          .from("answers")
+          .select("scenario_id, choice")
+          .eq("user_id", session.user.id);
+        if (!error && data) {
+          const mapped: Record<string, Choice> = {};
+          for (const row of data) {
+            if (row.scenario_id && row.choice) {
+              mapped[row.scenario_id] = row.choice as Choice;
+            }
+          }
+          setAnswersState(mapped);
+        }
+      } else {
+        setAnswersState(localAnswers);
+      }
+    };
+    load();
+  }, [localAnswers]);
+
+  const setAnswers = async (newAnswers: Record<string, Choice>) => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (session?.user) {
+      const rows = Object.entries(newAnswers).map(([scenario_id, choice]) => ({
+        user_id: session.user.id,
+        scenario_id,
+        choice,
+      }));
+      await supabase.from("answers").upsert(rows, { onConflict: "user_id,scenario_id" });
+      setAnswersState(newAnswers);
+    } else {
+      setLocalAnswers(newAnswers);
+      setAnswersState(newAnswers);
+    }
+  };
+
   return { answers, setAnswers };
 }

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -1,6 +1,8 @@
-
-import { useAnswers } from "@/hooks/useAnswers";
+import { useEffect, useState } from "react";
 import { useScenarios } from "@/hooks/useScenarios";
+import { supabase } from "@/integrations/supabase/client";
+
+const ANSWERS_KEY = "trolleyd-answers";
 
 /**
  * Minimal progress hook to satisfy Play.tsx import.
@@ -8,10 +10,30 @@ import { useScenarios } from "@/hooks/useScenarios";
  */
 export function useProgress(): any {
   const { scenarios } = useScenarios();
-  const { answers } = useAnswers() as any;
+  const [answered, setAnswered] = useState(0);
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (session?.user) {
+        const { count } = await supabase
+          .from("answers")
+          .select("id", { count: "exact", head: true })
+          .eq("user_id", session.user.id);
+        setAnswered(count ?? 0);
+      } else {
+        const stored = localStorage.getItem(ANSWERS_KEY);
+        const local = stored ? JSON.parse(stored) : {};
+        setAnswered(Object.keys(local).length);
+      }
+    };
+    load();
+  }, [scenarios]);
 
   const total = scenarios?.length ?? 0;
-  const answered = answers ? Object.keys(answers).length : 0;
   const percent = total > 0 ? Math.round((answered / total) * 100) : 0;
 
   return { total, answered, percent, value: percent };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -7,14 +7,107 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instanciate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: "13.0.4"
   }
   public: {
     Tables: {
-      [_ in never]: never
+      answers: {
+        Row: {
+          id: number
+          user_id: string | null
+          scenario_id: string | null
+          choice: string | null
+          rationale: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: number
+          user_id?: string | null
+          scenario_id?: string | null
+          choice?: string | null
+          rationale?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: number
+          user_id?: string | null
+          scenario_id?: string | null
+          choice?: string | null
+          rationale?: string | null
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "answers_user_id_fkey"
+            columns: ["user_id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+            referencedSchema?: "auth"
+          }
+        ]
+      }
+      profiles: {
+        Row: {
+          id: string
+          username: string | null
+          avatar_url: string | null
+          is_public: boolean | null
+        }
+        Insert: {
+          id: string
+          username?: string | null
+          avatar_url?: string | null
+          is_public?: boolean | null
+        }
+        Update: {
+          id?: string
+          username?: string | null
+          avatar_url?: string | null
+          is_public?: boolean | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profiles_id_fkey"
+            columns: ["id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+            referencedSchema?: "auth"
+          }
+        ]
+      }
+      ratings: {
+        Row: {
+          id: number
+          user_id: string | null
+          scenario_id: string | null
+          rating: number | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: number
+          user_id?: string | null
+          scenario_id?: string | null
+          rating?: number | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: number
+          user_id?: string | null
+          scenario_id?: string | null
+          rating?: number | null
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ratings_user_id_fkey"
+            columns: ["user_id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+            referencedSchema?: "auth"
+          }
+        ]
+      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/20240627000000_create_profiles_answers_ratings.sql
+++ b/supabase/migrations/20240627000000_create_profiles_answers_ratings.sql
@@ -1,0 +1,50 @@
+-- Create profiles table
+create table if not exists profiles (
+  id uuid primary key references auth.users(id),
+  username text,
+  avatar_url text,
+  is_public boolean default true
+);
+
+-- Create answers table
+create table if not exists answers (
+  id bigserial primary key,
+  user_id uuid references auth.users(id),
+  scenario_id text,
+  choice text,
+  rationale text,
+  created_at timestamptz default now()
+);
+
+-- Create ratings table
+create table if not exists ratings (
+  id bigserial primary key,
+  user_id uuid references auth.users(id),
+  scenario_id text,
+  rating int check (rating between 1 and 5),
+  created_at timestamptz default now()
+);
+
+-- Enable Row Level Security (RLS)
+alter table profiles enable row level security;
+alter table answers enable row level security;
+alter table ratings enable row level security;
+
+-- Policies for profiles
+create policy "Public profiles are viewable by everyone" on profiles
+  for select using (is_public or auth.uid() = id);
+
+create policy "Users can insert their own profile" on profiles
+  for insert with check (auth.uid() = id);
+
+create policy "Users can update their own profile" on profiles
+  for update using (auth.uid() = id);
+
+-- Policies for answers
+create policy "Users manage their own answers" on answers
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- Policies for ratings
+create policy "Users manage their own ratings" on ratings
+  for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+


### PR DESCRIPTION
## Summary
- create profiles, answers and ratings tables with RLS and policies
- sync answers with Supabase when signed in and fall back to local storage otherwise
- count progress from Supabase answers table when authenticated

## Testing
- `npx supabase gen types typescript --linked` *(fails: 403 Forbidden)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2dec8aec833086df27ddfc7b4957